### PR TITLE
feat: runtime resource tracking with AllocationTracker, Deadline, and frame limits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ pub use bridge::{OptimizationLevel, canonical_sort, optimize_node_order};
 #[cfg(feature = "zennode")]
 pub use orchestrate::{ProcessConfig, ProcessedImage, SourceImageInfo, StreamingOutput};
 
+// Re-export zencodecs quality types for callers resolving encode quality.
+pub use zencodecs::quality::{QualityIntent, QualityProfile};
+
 pub mod animation;
 pub mod codec;
 pub mod sidecar;
@@ -59,7 +62,9 @@ pub mod sidecar;
 pub use error::PipeError;
 pub use format::PixelFormat;
 pub use graph::{ResourceEstimate, SourceInfo};
-pub use limits::Limits;
+#[cfg(feature = "std")]
+pub use limits::Deadline;
+pub use limits::{AllocationGuard, AllocationTracker, Limits};
 pub use strip::{Strip, StripBuf};
 
 // Re-export key zenpixels-convert types.

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -2,6 +2,18 @@
 //!
 //! [`Limits`] prevents memory-bomb attacks by rejecting images that exceed
 //! configured dimension or pixel count thresholds before allocating.
+//!
+//! # Runtime enforcement
+//!
+//! [`AllocationTracker`] provides runtime memory tracking with RAII guards.
+//! Wrap each buffer allocation in [`allocate()`](AllocationTracker::allocate)
+//! and hold the returned [`AllocationGuard`] for the buffer's lifetime.
+//!
+//! [`Deadline`] (requires `std`) implements [`enough::Stop`] so it composes
+//! with the existing cancellation path in [`execute_with_stop`](crate::execute_with_stop).
+
+use alloc::sync::Arc;
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use crate::error::PipeError;
 use crate::format::PixelFormat;
@@ -20,7 +32,8 @@ use crate::format::PixelFormat;
 /// let limits = Limits::default()
 ///     .with_max_pixels(100_000_000)   // 100 megapixels
 ///     .with_max_width(16384)
-///     .with_max_height(16384);
+///     .with_max_height(16384)
+///     .with_max_frames(10000);
 /// ```
 #[derive(Debug, Clone, Copy, Default)]
 pub struct Limits {
@@ -32,6 +45,14 @@ pub struct Limits {
     pub max_width: Option<u32>,
     /// Maximum image height in pixels.
     pub max_height: Option<u32>,
+    /// Maximum animation frame count.
+    pub max_frames: Option<u32>,
+    /// Maximum job duration.
+    ///
+    /// Use [`to_deadline()`](Limits::to_deadline) to create a [`Deadline`]
+    /// that implements [`enough::Stop`].
+    #[cfg(feature = "std")]
+    pub max_duration: Option<core::time::Duration>,
 }
 
 impl Limits {
@@ -41,14 +62,21 @@ impl Limits {
         max_memory_bytes: None,
         max_width: None,
         max_height: None,
+        max_frames: None,
+        #[cfg(feature = "std")]
+        max_duration: None,
     };
 
-    /// Server-safe defaults: 100 megapixels, 16384 max dimension, 4 GB memory.
+    /// Server-safe defaults: 100 megapixels, 16384 max dimension, 4 GB memory,
+    /// 10 000 animation frames.
     pub const SERVER: Self = Self {
         max_pixels: Some(100_000_000),
         max_memory_bytes: Some(4 * 1024 * 1024 * 1024),
         max_width: Some(16384),
         max_height: Some(16384),
+        max_frames: Some(10_000),
+        #[cfg(feature = "std")]
+        max_duration: None,
     };
 
     pub fn with_max_pixels(mut self, max: u64) -> Self {
@@ -68,6 +96,19 @@ impl Limits {
 
     pub fn with_max_height(mut self, max: u32) -> Self {
         self.max_height = Some(max);
+        self
+    }
+
+    /// Set maximum animation frame count.
+    pub fn with_max_frames(mut self, max: u32) -> Self {
+        self.max_frames = Some(max);
+        self
+    }
+
+    /// Set maximum job duration (requires `std`).
+    #[cfg(feature = "std")]
+    pub fn with_max_duration(mut self, max: core::time::Duration) -> Self {
+        self.max_duration = Some(max);
         self
     }
 
@@ -109,5 +150,303 @@ impl Limits {
         }
 
         Ok(())
+    }
+
+    /// Check whether a frame count is within limits.
+    ///
+    /// Returns `Ok(())` if within limits or no frame limit is set.
+    pub fn check_frames(&self, count: u32) -> Result<(), PipeError> {
+        if let Some(max) = self.max_frames {
+            if count > max {
+                return Err(PipeError::LimitExceeded(alloc::format!(
+                    "frame count {count} exceeds max {max}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Create a [`Deadline`] from `max_duration`, if set.
+    ///
+    /// The deadline starts from the moment this method is called.
+    #[cfg(feature = "std")]
+    pub fn to_deadline(&self) -> Option<Deadline> {
+        self.max_duration.map(Deadline::new)
+    }
+
+    /// Create an [`AllocationTracker`] from `max_memory_bytes`, if set.
+    ///
+    /// Returns an unlimited tracker when no memory limit is configured.
+    pub fn to_allocation_tracker(self) -> Arc<AllocationTracker> {
+        Arc::new(match self.max_memory_bytes {
+            Some(limit) => AllocationTracker::new(limit),
+            None => AllocationTracker::unlimited(),
+        })
+    }
+}
+
+// =========================================================================
+// AllocationTracker — runtime memory accounting
+// =========================================================================
+
+/// Thread-safe runtime memory tracker with RAII guards.
+///
+/// Tracks current and peak memory usage across all allocations.
+/// Each [`allocate()`](Self::allocate) call returns an [`AllocationGuard`]
+/// that decrements the counter on drop.
+///
+/// # `no_std` compatible
+///
+/// Uses only `core::sync::atomic` — works in `no_std + alloc` environments.
+///
+/// # Example
+///
+/// ```
+/// use std::sync::Arc;
+/// use zenpipe::limits::AllocationTracker;
+///
+/// let tracker = Arc::new(AllocationTracker::new(1024 * 1024)); // 1 MB limit
+///
+/// // Allocate 512 KB — succeeds
+/// let guard = tracker.allocate(512 * 1024).unwrap();
+/// assert_eq!(tracker.current_bytes(), 512 * 1024);
+///
+/// // Try another 512 KB + 1 — fails (would exceed 1 MB)
+/// assert!(tracker.allocate(512 * 1024 + 1).is_err());
+///
+/// // Drop the first guard — frees the 512 KB
+/// drop(guard);
+/// assert_eq!(tracker.current_bytes(), 0);
+/// ```
+pub struct AllocationTracker {
+    current_bytes: AtomicU64,
+    peak_bytes: AtomicU64,
+    allocation_count: AtomicU64,
+    /// Memory limit in bytes. 0 = unlimited.
+    limit_bytes: u64,
+}
+
+impl core::fmt::Debug for AllocationTracker {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocationTracker")
+            .field("current_bytes", &self.current_bytes())
+            .field("peak_bytes", &self.peak_bytes())
+            .field("allocation_count", &self.allocation_count())
+            .field("limit_bytes", &self.limit_bytes)
+            .finish()
+    }
+}
+
+impl AllocationTracker {
+    /// Create a tracker with the given byte limit.
+    ///
+    /// Pass `0` for unlimited (equivalent to [`unlimited()`](Self::unlimited)).
+    pub fn new(limit_bytes: u64) -> Self {
+        Self {
+            current_bytes: AtomicU64::new(0),
+            peak_bytes: AtomicU64::new(0),
+            allocation_count: AtomicU64::new(0),
+            limit_bytes,
+        }
+    }
+
+    /// Create a tracker with no memory limit.
+    pub fn unlimited() -> Self {
+        Self::new(0)
+    }
+
+    /// Record an allocation of `bytes` and return an RAII guard.
+    ///
+    /// Returns `Err(PipeError::LimitExceeded)` if the allocation would
+    /// push `current_bytes` past the configured limit.
+    ///
+    /// The returned [`AllocationGuard`] decrements `current_bytes` on drop.
+    pub fn allocate(self: &Arc<Self>, bytes: u64) -> Result<AllocationGuard, PipeError> {
+        self.check(bytes)?;
+
+        let new_total = self.current_bytes.fetch_add(bytes, Ordering::SeqCst) + bytes;
+        self.peak_bytes.fetch_max(new_total, Ordering::SeqCst);
+        self.allocation_count.fetch_add(1, Ordering::SeqCst);
+
+        Ok(AllocationGuard {
+            tracker: Arc::clone(self),
+            bytes,
+        })
+    }
+
+    /// Try to record an allocation, returning `None` on limit violation
+    /// instead of an error.
+    pub fn try_allocate(self: &Arc<Self>, bytes: u64) -> Option<AllocationGuard> {
+        self.allocate(bytes).ok()
+    }
+
+    /// Check whether `requested` bytes can be allocated without exceeding
+    /// the limit. Does **not** actually allocate.
+    pub fn check(&self, requested: u64) -> Result<(), PipeError> {
+        if self.limit_bytes > 0 {
+            let current = self.current_bytes.load(Ordering::SeqCst);
+            if current + requested > self.limit_bytes {
+                return Err(PipeError::LimitExceeded(alloc::format!(
+                    "memory: {} + {} = {} bytes exceeds limit {}",
+                    current,
+                    requested,
+                    current + requested,
+                    self.limit_bytes,
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Current allocated bytes.
+    pub fn current_bytes(&self) -> u64 {
+        self.current_bytes.load(Ordering::SeqCst)
+    }
+
+    /// Peak allocated bytes (high-water mark).
+    pub fn peak_bytes(&self) -> u64 {
+        self.peak_bytes.load(Ordering::SeqCst)
+    }
+
+    /// Total number of allocations made (including released ones).
+    pub fn allocation_count(&self) -> u64 {
+        self.allocation_count.load(Ordering::SeqCst)
+    }
+
+    /// Configured memory limit (0 = unlimited).
+    pub fn limit_bytes(&self) -> u64 {
+        self.limit_bytes
+    }
+
+    /// Remaining capacity before hitting the limit, or `None` if unlimited.
+    pub fn remaining(&self) -> Option<u64> {
+        if self.limit_bytes == 0 {
+            None
+        } else {
+            Some(
+                self.limit_bytes
+                    .saturating_sub(self.current_bytes.load(Ordering::SeqCst)),
+            )
+        }
+    }
+}
+
+impl Default for AllocationTracker {
+    fn default() -> Self {
+        Self::unlimited()
+    }
+}
+
+// =========================================================================
+// AllocationGuard — RAII decrement on drop
+// =========================================================================
+
+/// RAII guard that decrements an [`AllocationTracker`] on drop.
+///
+/// Returned by [`AllocationTracker::allocate()`]. Hold this for the
+/// lifetime of the associated buffer.
+pub struct AllocationGuard {
+    tracker: Arc<AllocationTracker>,
+    bytes: u64,
+}
+
+impl AllocationGuard {
+    /// Size of this allocation in bytes.
+    pub fn bytes(&self) -> u64 {
+        self.bytes
+    }
+}
+
+impl Drop for AllocationGuard {
+    fn drop(&mut self) {
+        self.tracker
+            .current_bytes
+            .fetch_sub(self.bytes, Ordering::SeqCst);
+    }
+}
+
+impl core::fmt::Debug for AllocationGuard {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AllocationGuard")
+            .field("bytes", &self.bytes)
+            .finish()
+    }
+}
+
+// =========================================================================
+// Deadline — Stop implementation with a wall-clock timeout
+// =========================================================================
+
+/// A [`Stop`](enough::Stop) implementation that expires after a fixed duration.
+///
+/// Created from [`Limits::to_deadline()`] or directly via [`Deadline::new()`].
+/// Composes with [`execute_with_stop`](crate::execute_with_stop) — pass as
+/// the `stop` parameter to enforce a wall-clock timeout on pipeline execution.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+/// use enough::Stop;
+/// use zenpipe::limits::Deadline;
+///
+/// let deadline = Deadline::new(Duration::from_secs(30));
+/// assert!(deadline.check().is_ok()); // fresh — hasn't expired yet
+/// ```
+///
+/// # Requires `std`
+///
+/// Uses `std::time::Instant` for monotonic time.
+#[cfg(feature = "std")]
+pub struct Deadline {
+    start: std::time::Instant,
+    max_duration: core::time::Duration,
+}
+
+#[cfg(feature = "std")]
+impl Deadline {
+    /// Create a deadline that expires `max_duration` from now.
+    pub fn new(max_duration: core::time::Duration) -> Self {
+        Self {
+            start: std::time::Instant::now(),
+            max_duration,
+        }
+    }
+
+    /// Elapsed time since the deadline was created.
+    pub fn elapsed(&self) -> core::time::Duration {
+        self.start.elapsed()
+    }
+
+    /// Remaining time before the deadline expires, or zero if already expired.
+    pub fn remaining(&self) -> core::time::Duration {
+        self.max_duration.saturating_sub(self.start.elapsed())
+    }
+
+    /// Whether the deadline has expired.
+    pub fn is_expired(&self) -> bool {
+        self.start.elapsed() >= self.max_duration
+    }
+}
+
+#[cfg(feature = "std")]
+impl core::fmt::Debug for Deadline {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Deadline")
+            .field("elapsed", &self.elapsed())
+            .field("max_duration", &self.max_duration)
+            .field("expired", &self.is_expired())
+            .finish()
+    }
+}
+
+#[cfg(feature = "std")]
+impl enough::Stop for Deadline {
+    fn check(&self) -> Result<(), enough::StopReason> {
+        if self.is_expired() {
+            Err(enough::StopReason::Cancelled)
+        } else {
+            Ok(())
+        }
     }
 }

--- a/tests/limits.rs
+++ b/tests/limits.rs
@@ -204,3 +204,189 @@ fn server_limits_reject_huge_image() {
     // 16384×16384 RGBA8 = 1 TB memory, exceeds 4 GB max_memory
     assert!(limits.check(16384, 16384, format::RGBA8_SRGB).is_err());
 }
+
+#[test]
+fn server_limits_have_frame_limit() {
+    let limits = Limits::SERVER;
+    assert_eq!(limits.max_frames, Some(10_000));
+}
+
+// =========================================================================
+// Frame count checks
+// =========================================================================
+
+#[test]
+fn check_frames_within_limit() {
+    let limits = Limits::default().with_max_frames(100);
+    assert!(limits.check_frames(50).is_ok());
+    assert!(limits.check_frames(100).is_ok());
+}
+
+#[test]
+fn check_frames_exceeds_limit() {
+    let limits = Limits::default().with_max_frames(100);
+    let err = limits.check_frames(101);
+    assert!(matches!(err, Err(PipeError::LimitExceeded(_))));
+}
+
+#[test]
+fn check_frames_no_limit() {
+    let limits = Limits::NONE;
+    assert!(limits.check_frames(u32::MAX).is_ok());
+}
+
+// =========================================================================
+// AllocationTracker
+// =========================================================================
+
+use std::sync::Arc;
+use zenpipe::AllocationTracker;
+
+#[test]
+fn tracker_allocate_and_track() {
+    let tracker = Arc::new(AllocationTracker::new(1024));
+
+    let g1 = tracker.allocate(400).unwrap();
+    assert_eq!(tracker.current_bytes(), 400);
+    assert_eq!(tracker.peak_bytes(), 400);
+    assert_eq!(tracker.allocation_count(), 1);
+
+    let g2 = tracker.allocate(300).unwrap();
+    assert_eq!(tracker.current_bytes(), 700);
+    assert_eq!(tracker.peak_bytes(), 700);
+    assert_eq!(tracker.allocation_count(), 2);
+
+    drop(g1);
+    assert_eq!(tracker.current_bytes(), 300);
+    // Peak should remain at 700
+    assert_eq!(tracker.peak_bytes(), 700);
+
+    drop(g2);
+    assert_eq!(tracker.current_bytes(), 0);
+    assert_eq!(tracker.peak_bytes(), 700);
+}
+
+#[test]
+fn tracker_exceeds_limit() {
+    let tracker = Arc::new(AllocationTracker::new(1000));
+    let _g = tracker.allocate(600).unwrap();
+
+    // 600 + 500 = 1100 > 1000
+    let err = tracker.allocate(500);
+    assert!(err.is_err());
+    assert!(matches!(err.unwrap_err(), PipeError::LimitExceeded(_)));
+
+    // Current should be unchanged (allocation was rejected)
+    assert_eq!(tracker.current_bytes(), 600);
+}
+
+#[test]
+fn tracker_guard_drops_decrement() {
+    let tracker = Arc::new(AllocationTracker::new(0)); // unlimited
+    {
+        let _g1 = tracker.allocate(100).unwrap();
+        let _g2 = tracker.allocate(200).unwrap();
+        assert_eq!(tracker.current_bytes(), 300);
+    }
+    // Both guards dropped
+    assert_eq!(tracker.current_bytes(), 0);
+    assert_eq!(tracker.peak_bytes(), 300);
+}
+
+#[test]
+fn tracker_unlimited_allows_large() {
+    let tracker = Arc::new(AllocationTracker::unlimited());
+    let _g = tracker.allocate(u64::MAX / 2).unwrap();
+    assert_eq!(tracker.current_bytes(), u64::MAX / 2);
+}
+
+#[test]
+fn tracker_try_allocate_returns_none() {
+    let tracker = Arc::new(AllocationTracker::new(100));
+    let _g = tracker.allocate(80).unwrap();
+
+    assert!(tracker.try_allocate(30).is_none());
+    assert!(tracker.try_allocate(20).is_some());
+}
+
+#[test]
+fn tracker_check_without_allocating() {
+    let tracker = Arc::new(AllocationTracker::new(1000));
+    let _g = tracker.allocate(800).unwrap();
+
+    // check does not actually allocate
+    assert!(tracker.check(100).is_ok());
+    assert!(tracker.check(300).is_err());
+    assert_eq!(tracker.current_bytes(), 800); // unchanged
+}
+
+#[test]
+fn tracker_remaining_capacity() {
+    let tracker = Arc::new(AllocationTracker::new(1000));
+    assert_eq!(tracker.remaining(), Some(1000));
+
+    let _g = tracker.allocate(400).unwrap();
+    assert_eq!(tracker.remaining(), Some(600));
+
+    let unlimited = Arc::new(AllocationTracker::unlimited());
+    assert_eq!(unlimited.remaining(), None);
+}
+
+#[test]
+fn tracker_from_limits() {
+    let limits = Limits::default().with_max_memory_bytes(2048);
+    let tracker = limits.to_allocation_tracker();
+    assert_eq!(tracker.limit_bytes(), 2048);
+
+    let no_limit = Limits::NONE.to_allocation_tracker();
+    assert_eq!(no_limit.limit_bytes(), 0);
+}
+
+// =========================================================================
+// Deadline
+// =========================================================================
+
+use std::time::Duration;
+use zenpipe::Deadline;
+
+#[test]
+fn deadline_fresh_passes_check() {
+    let deadline = Deadline::new(Duration::from_secs(60));
+    assert!(deadline.check().is_ok());
+    assert!(!deadline.is_expired());
+    assert!(deadline.remaining() > Duration::ZERO);
+}
+
+#[test]
+fn deadline_expired_fails_check() {
+    let deadline = Deadline::new(Duration::from_nanos(1));
+    // Burn through the nanosecond
+    std::thread::sleep(Duration::from_millis(1));
+    assert!(deadline.is_expired());
+    assert!(deadline.check().is_err());
+    assert_eq!(deadline.remaining(), Duration::ZERO);
+}
+
+#[test]
+fn deadline_from_limits() {
+    let limits = Limits::default().with_max_duration(Duration::from_secs(5));
+    let deadline = limits.to_deadline();
+    assert!(deadline.is_some());
+    let d = deadline.unwrap();
+    assert!(d.check().is_ok());
+
+    let no_deadline = Limits::NONE.to_deadline();
+    assert!(no_deadline.is_none());
+}
+
+#[test]
+fn deadline_compose_with_execute() {
+    // A deadline that has already expired should cancel execute_with_stop
+    let deadline = Deadline::new(Duration::from_nanos(1));
+    std::thread::sleep(Duration::from_millis(1));
+
+    let mut src = solid_source(4, 100);
+    let mut sink = CollectSink::new();
+    let result = zenpipe::execute_with_stop(&mut *src, &mut sink, &deadline);
+    assert!(matches!(result, Err(PipeError::Cancelled)));
+}


### PR DESCRIPTION
## Summary

Upgrades zenpipe from static pre-execution resource checks to runtime enforcement.

- **AllocationTracker** — no_std-compatible (AtomicU64) thread-safe memory tracker with RAII `AllocationGuard`
- **Deadline** — implements `enough::Stop` for job timeout enforcement, composes with `execute_with_stop()`
- **Frame limits** — `max_frames: Option<u32>` on `Limits` (SERVER default: 10,000)
- **Duration limits** — `max_duration: Option<Duration>` with `to_deadline()` factory
- **Convenience** — `to_allocation_tracker()`, `with_max_frames()`, `with_max_duration()` builders

## Test plan

- [x] AllocationTracker: allocate, peak tracking, guard drop decrements, limit enforcement
- [x] Deadline: fresh passes, expired fails, Stop trait integration
- [x] Frame/duration limit checks
- [x] 29 total limits tests passing

Closes #7