### PR TITLE
feat: resolve quality profiles via zencodecs QualityIntent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,11 +53,11 @@ dependencies = [
 
 [[package]]
 name = "archmage"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31252c47e70c7056709e9f98842aef4f709056c2b3a4f666c584f8cc37f7ca0"
+checksum = "04abfbadff681a305ecd3db04ce891981aa9696d8c13058237e6a6417108fcfe"
 dependencies = [
- "archmage-macros 0.9.12",
+ "archmage-macros 0.9.13",
  "safe_unaligned_simd",
 ]
 
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "archmage-macros"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a97189db9dffc2e13364c6f56461085d65743ff4d17890d6b80744203aae92b"
+checksum = "50a1d7ac60f40ab79a2b06f49d3863a4da7569ce8ed708c1eae163d30ce41d28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -261,7 +261,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ee8d8f5e43a45183480ea077c4e046e43ab9604928c87d6ad2080e666dc519"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "paste",
 ]
@@ -374,7 +374,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4b75067bc1e8c2c28413cab5777c0fe8473499e55f2e09076b9076f344ce9d5"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "magetypes",
  "num-traits",
@@ -401,7 +401,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c805c315148e092279cd19d011ce4b22ff9d3cc593cca089364f6501d12087b1"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ name = "zenavif"
 version = "0.1.0"
 dependencies = [
  "almost-enough",
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "enough",
  "imgref",
@@ -847,7 +847,7 @@ dependencies = [
 name = "zenblend"
 version = "0.1.0"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "magetypes",
  "safe_unaligned_simd",
  "wide",
@@ -866,10 +866,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zencodecs"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "enough",
+ "imgref",
+ "linear-srgb",
+ "rgb",
+ "thiserror",
+ "whereat",
+ "zencodec",
+ "zenpixels",
+ "zenpixels-convert",
+]
+
+[[package]]
 name = "zenfilters"
 version = "0.1.0"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "linear-srgb",
  "magetypes",
@@ -885,7 +901,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3ab3b331bb33391f2ac0a0716b5a5a06c634c3726f7a69b68d3052dbd2602f8"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "enough",
  "libm",
 ]
@@ -895,7 +911,7 @@ name = "zenflate"
 version = "0.3.2"
 source = "git+https://github.com/imazen/zenflate#67987f71379722e52106fca50e1717113e46d384"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "enough",
  "libm",
 ]
@@ -923,7 +939,7 @@ name = "zenjpeg"
 version = "0.6.1"
 dependencies = [
  "aligned-vec",
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "enough",
  "imgref",
@@ -999,6 +1015,7 @@ dependencies = [
  "zenbitmaps",
  "zenblend",
  "zencodec",
+ "zencodecs",
  "zenfilters",
  "zengif",
  "zenjpeg",
@@ -1034,7 +1051,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15525e70fac3b3a6c2f7e3826c4e11376dd3ae885eaa7fe0aa252238381c3732"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "garb",
  "linear-srgb",
@@ -1049,7 +1066,7 @@ name = "zenpng"
 version = "0.1.0"
 dependencies = [
  "almost-enough",
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "enough",
  "imgref",
@@ -1069,7 +1086,7 @@ dependencies = [
 name = "zenquant"
 version = "0.1.1"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "imgref",
  "linear-srgb",
  "magetypes",
@@ -1085,7 +1102,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a5766f917b4a5e3321e7e64401fa3158e6db006996f83fb511b40f39b405cd"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "imgref",
  "linear-srgb",
  "magetypes",
@@ -1098,7 +1115,7 @@ dependencies = [
 name = "zenresize"
 version = "0.1.0"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "imgref",
  "libm",
  "linear-srgb",
@@ -1161,6 +1178,7 @@ version = "0.1.0"
 name = "zenwebp"
 version = "0.3.2"
 dependencies = [
+ "archmage 0.9.13",
  "bytemuck",
  "byteorder-lite",
  "enough",
@@ -1168,6 +1186,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "libm",
  "linear-srgb",
+ "magetypes",
  "self_cell",
  "thiserror",
  "whereat",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,8 @@ zenpixels-convert = { version = "0.2.0", default-features = false }
 zenpixels = { version = "0.2.0", default-features = false }
 # Codec trait abstraction (decode/encode, animation, streaming)
 zencodec = { version = "0.1.5", default-features = false }
+# Quality profiles, per-codec calibration, format selection (no codec impls)
+zencodecs = { path = "../zencodecs", default-features = false }
 # Cooperative cancellation
 enough = { version = "0.4", default-features = false }
 # Error location tracking (re-exported by zenpixels for BufferError)

--- a/src/bridge/config.rs
+++ b/src/bridge/config.rs
@@ -3,6 +3,7 @@
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 
+use zencodecs::quality::{QualityIntent, QualityProfile};
 use zennode::NodeInstance;
 
 /// Decode-time configuration extracted from the Decode node's params.
@@ -167,5 +168,251 @@ impl EncodeConfig {
         }
 
         config
+    }
+
+    /// Resolve the quality profile string to a [`QualityProfile`].
+    ///
+    /// Parses named presets (`"good"`, `"high"`, `"lossless"`, etc.) and
+    /// numeric values (`"85"` maps to nearest profile). Returns
+    /// [`QualityProfile::Good`] if no profile is set or parsing fails.
+    pub fn resolve_profile(&self) -> QualityProfile {
+        self.quality_profile
+            .as_deref()
+            .and_then(QualityProfile::parse)
+            .unwrap_or_default()
+    }
+
+    /// Resolve the string quality profile to a [`QualityIntent`] with
+    /// per-codec calibrated quality tables.
+    ///
+    /// Applies DPR adjustment (baseline DPR 3.0: DPR 1.0 boosts quality,
+    /// DPR 6.0 lowers it). Applies lossless override when set.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use zenpipe::EncodeConfig;
+    ///
+    /// let config = EncodeConfig {
+    ///     quality_profile: Some("high".into()),
+    ///     dpr: 1.0,
+    ///     lossless: Some(false),
+    ///     ..Default::default()
+    /// };
+    /// let intent = config.resolve_quality();
+    /// assert_eq!(intent.jpeg_quality(), 97); // DPR 1.0 boosts "high" (91) to ~97
+    /// assert!(!intent.lossless);
+    /// ```
+    pub fn resolve_quality(&self) -> QualityIntent {
+        let profile = self.resolve_profile();
+
+        // Apply DPR adjustment. The baseline DPR is 3.0 (no adjustment).
+        // Typical web usage: dpr=1.0 (desktop retina) to dpr=3.0 (high-res mobile).
+        // The default dpr field is 1.0, matching the common "prepare for retina
+        // upscaling" use case. When the caller hasn't set DPR at all (field == 1.0
+        // from default), apply the adjustment — a DPR 1.0 image needs higher quality
+        // because the browser will magnify it ~3x.
+        let mut intent = profile.to_intent_with_dpr(self.dpr);
+
+        // Apply lossless override.
+        if self.lossless == Some(true) {
+            intent.lossless = true;
+        }
+
+        intent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_profile_named_good() {
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            ..Default::default()
+        };
+        assert_eq!(config.resolve_profile(), QualityProfile::Good);
+    }
+
+    #[test]
+    fn resolve_profile_named_high() {
+        let config = EncodeConfig {
+            quality_profile: Some("high".into()),
+            ..Default::default()
+        };
+        assert_eq!(config.resolve_profile(), QualityProfile::High);
+    }
+
+    #[test]
+    fn resolve_profile_named_lossless() {
+        let config = EncodeConfig {
+            quality_profile: Some("lossless".into()),
+            ..Default::default()
+        };
+        assert_eq!(config.resolve_profile(), QualityProfile::Lossless);
+    }
+
+    #[test]
+    fn resolve_profile_numeric() {
+        let config = EncodeConfig {
+            quality_profile: Some("85".into()),
+            ..Default::default()
+        };
+        // 85 maps to High (82-93.5 range)
+        assert_eq!(config.resolve_profile(), QualityProfile::High);
+    }
+
+    #[test]
+    fn resolve_profile_none_defaults_to_good() {
+        let config = EncodeConfig::default();
+        assert_eq!(config.resolve_profile(), QualityProfile::Good);
+    }
+
+    #[test]
+    fn resolve_profile_invalid_defaults_to_good() {
+        let config = EncodeConfig {
+            quality_profile: Some("bogus".into()),
+            ..Default::default()
+        };
+        assert_eq!(config.resolve_profile(), QualityProfile::Good);
+    }
+
+    #[test]
+    fn resolve_quality_good_at_dpr_3() {
+        // DPR 3.0 = baseline = no DPR adjustment.
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            dpr: 3.0,
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        // Good profile generic quality = 73.0, JPEG table maps 73 -> 73.
+        assert_eq!(intent.jpeg_quality(), 73);
+        assert!(!intent.lossless);
+    }
+
+    #[test]
+    fn resolve_quality_good_at_dpr_1_boosts() {
+        // DPR 1.0 boosts quality: artifacts are magnified ~3x by browser.
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            dpr: 1.0,
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        // Good (73) with DPR 1.0 -> quality ~91 -> JPEG ~91
+        assert_eq!(intent.jpeg_quality(), 91);
+    }
+
+    #[test]
+    fn resolve_quality_good_at_dpr_6_lowers() {
+        // DPR 6.0 lowers quality: source pixels are tiny on screen.
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            dpr: 6.0,
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        // Good (73) with DPR 6.0 -> quality ~46 -> JPEG ~46
+        // (interpolated between anchors 34->34 and 55->57)
+        let jpeg_q = intent.jpeg_quality();
+        assert!(
+            jpeg_q < 60,
+            "DPR 6.0 should lower JPEG quality below 60, got {jpeg_q}"
+        );
+    }
+
+    #[test]
+    fn resolve_quality_lossless_override() {
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            dpr: 3.0,
+            lossless: Some(true),
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        assert!(intent.lossless);
+    }
+
+    #[test]
+    fn resolve_quality_lossless_false_not_set() {
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            dpr: 3.0,
+            lossless: Some(false),
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        assert!(!intent.lossless);
+    }
+
+    #[test]
+    fn resolve_quality_lossless_none_not_set() {
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            dpr: 3.0,
+            lossless: None,
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        assert!(!intent.lossless);
+    }
+
+    #[test]
+    fn resolve_quality_default_config() {
+        // Default config: no profile, dpr=1.0, no lossless.
+        let config = EncodeConfig::default();
+        let intent = config.resolve_quality();
+        // Default profile is Good (73), DPR 1.0 boosts -> ~91.
+        assert_eq!(intent.jpeg_quality(), 91);
+        assert!(!intent.lossless);
+    }
+
+    #[test]
+    fn resolve_quality_per_codec_calibration() {
+        // Verify that different codecs get different values from the same profile.
+        let config = EncodeConfig {
+            quality_profile: Some("good".into()),
+            dpr: 3.0,
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        assert_eq!(intent.jpeg_quality(), 73);
+        // WebP has slightly different calibration: generic 73 -> WebP 76
+        assert!((intent.webp_quality() - 76.0).abs() < 0.01);
+        // JXL distance: generic 73 -> distance 2.58
+        assert!((intent.jxl_distance() - 2.58).abs() < 0.01);
+    }
+
+    #[test]
+    fn resolve_quality_lossless_profile() {
+        let config = EncodeConfig {
+            quality_profile: Some("lossless".into()),
+            dpr: 3.0,
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        // Lossless profile sets the flag automatically.
+        assert!(intent.lossless);
+        // DPR adjustment clamps quality to 5..99 range, so even lossless
+        // (generic 100) gets clamped to 99 -> JPEG 99. The lossless flag
+        // is what actually controls lossless encoding, not the quality number.
+        assert_eq!(intent.jpeg_quality(), 99);
+    }
+
+    #[test]
+    fn resolve_quality_high_at_dpr_1() {
+        let config = EncodeConfig {
+            quality_profile: Some("high".into()),
+            dpr: 1.0,
+            lossless: Some(false),
+            ..Default::default()
+        };
+        let intent = config.resolve_quality();
+        // High (91) with DPR 1.0 -> quality ~97 -> JPEG 97
+        assert_eq!(intent.jpeg_quality(), 97);
+        assert!(!intent.lossless);
     }
 }

--- a/src/bridge/convert.rs
+++ b/src/bridge/convert.rs
@@ -358,329 +358,332 @@ pub(crate) fn convert_round_corners(node: &dyn NodeInstance) -> Result<NodeOp, P
         param_u32(node, "bg_a").unwrap_or(0) as u8,
     ];
 
-    Ok(NodeOp::Materialize { label: "round_corners", transform: Box::new(move |data, w, h, fmt| {
-        let width = *w;
-        let height = *h;
-        let bpp = fmt.bytes_per_pixel();
-        if width == 0 || height == 0 {
-            return;
-        }
-
-        let smallest = width.min(height) as f32;
-
-        // Resolve per-corner radii from mode + parameters.
-        // Returns [top_left, top_right, bottom_left, bottom_right] clamped to valid range.
-        let has_custom =
-            radius_tl >= 0.0 || radius_tr >= 0.0 || radius_bl >= 0.0 || radius_br >= 0.0;
-        let is_circle = mode == "circle";
-        let is_percentage = mode == "percentage" || mode == "percentage_custom";
-
-        let corner_radii: [f32; 4] = if is_circle {
-            let r = smallest / 2.0;
-            [r, r, r, r]
-        } else if has_custom {
-            let tl = if radius_tl >= 0.0 { radius_tl } else { radius };
-            let tr = if radius_tr >= 0.0 { radius_tr } else { radius };
-            let bl = if radius_bl >= 0.0 { radius_bl } else { radius };
-            let br = if radius_br >= 0.0 { radius_br } else { radius };
-            if is_percentage {
-                [
-                    smallest * tl.clamp(0.0, 100.0) / 200.0,
-                    smallest * tr.clamp(0.0, 100.0) / 200.0,
-                    smallest * bl.clamp(0.0, 100.0) / 200.0,
-                    smallest * br.clamp(0.0, 100.0) / 200.0,
-                ]
-            } else {
-                let half = smallest / 2.0;
-                [
-                    tl.clamp(0.0, half),
-                    tr.clamp(0.0, half),
-                    bl.clamp(0.0, half),
-                    br.clamp(0.0, half),
-                ]
-            }
-        } else if is_percentage {
-            let r = smallest * radius.clamp(0.0, 100.0) / 200.0;
-            [r, r, r, r]
-        } else {
-            let r = radius.clamp(0.0, smallest / 2.0);
-            [r, r, r, r]
-        };
-
-        // Check if all radii are zero — nothing to do.
-        if corner_radii.iter().all(|&r| r <= 0.0) {
-            return;
-        }
-
-        // For circle mode on non-square canvases, compute offsets to center the circle.
-        // This matches V2's plan_quadrants Circle logic: the quadrants are offset so the
-        // circular region is centered in the larger dimension.
-        let (offset_x, offset_y) = if is_circle {
-            let ox = ((width as i64 - height as i64).max(0) / 2) as u32;
-            let oy = ((height as i64 - width as i64).max(0) / 2) as u32;
-            (ox, oy)
-        } else {
-            (0, 0)
-        };
-
-        // The effective canvas for quadrant computation (smallest dimension for circle).
-        let eff_w = if is_circle { smallest as u32 } else { width };
-        let eff_h = if is_circle { smallest as u32 } else { height };
-
-        // Integer division to avoid quadrant overlap on odd dimensions (matches V2).
-        let right_half_width = eff_w / 2;
-        let bottom_half_height = eff_h / 2;
-        let left_half_width = eff_w - right_half_width;
-        let top_half_height = eff_h - bottom_half_height;
-
-        // Volumetric offset: radius of a circle with the surface area of a 1x1 square.
-        let volumetric_offset: f32 = 0.56419; // sqrt(1/pi)
-
-        // Pre-convert bg color to linear space for gamma-correct blending.
-        let bg_linear: [f32; 4] = [
-            srgb_byte_to_linear(bg[0]),
-            srgb_byte_to_linear(bg[1]),
-            srgb_byte_to_linear(bg[2]),
-            bg[3] as f32 / 255.0,
-        ];
-
-        // Fill a rectangular region with the background color.
-        let fill_rect = |data: &mut [u8], x1: u32, y1: u32, x2: u32, y2: u32| {
-            let x1 = x1 as usize;
-            let y1 = y1 as usize;
-            let x2 = (x2 as usize).min(width as usize);
-            let y2 = (y2 as usize).min(height as usize);
-            for y in y1..y2 {
-                let row_start = y * width as usize * bpp;
-                for x in x1..x2 {
-                    let off = row_start + x * bpp;
-                    for c in 0..bpp.min(4) {
-                        data[off + c] = bg[c];
-                    }
-                }
-            }
-        };
-
-        // For circle mode: clear the top/bottom/left/right strips outside the circle region.
-        if is_circle {
-            // Clear top rows (above the circle region).
-            if offset_y > 0 {
-                fill_rect(data, 0, 0, width, offset_y);
-            }
-            // Clear bottom rows (below the circle region).
-            let circle_bottom = offset_y + eff_h;
-            if circle_bottom < height {
-                fill_rect(data, 0, circle_bottom, width, height);
-            }
-            // Clear left columns (left of the circle region) within the circle rows.
-            if offset_x > 0 {
-                fill_rect(data, 0, offset_y, offset_x, offset_y + eff_h);
-            }
-            // Clear right columns (right of the circle region) within the circle rows.
-            let circle_right = offset_x + eff_w;
-            if circle_right < width {
-                fill_rect(data, circle_right, offset_y, width, offset_y + eff_h);
-            }
-        }
-
-        // Quadrant definitions: [top_left, top_right, bottom_left, bottom_right]
-        // Each: (qx, qy, qw, qh, radius, center_x, center_y, is_top, is_left)
-        struct Quadrant {
-            qx: u32,
-            qy: u32,
-            qw: u32,
-            qh: u32,
-            radius: f32,
-            cx: f32,
-            cy: f32,
-            is_top: bool,
-            is_left: bool,
-        }
-
-        let quadrants = [
-            Quadrant {
-                qx: offset_x,
-                qy: offset_y,
-                qw: left_half_width,
-                qh: top_half_height,
-                radius: corner_radii[0],
-                cx: offset_x as f32 + corner_radii[0],
-                cy: offset_y as f32 + corner_radii[0],
-                is_top: true,
-                is_left: true,
-            },
-            Quadrant {
-                qx: offset_x + left_half_width,
-                qy: offset_y,
-                qw: right_half_width,
-                qh: top_half_height,
-                radius: corner_radii[1],
-                cx: offset_x as f32 + eff_w as f32 - corner_radii[1],
-                cy: offset_y as f32 + corner_radii[1],
-                is_top: true,
-                is_left: false,
-            },
-            Quadrant {
-                qx: offset_x,
-                qy: offset_y + top_half_height,
-                qw: left_half_width,
-                qh: bottom_half_height,
-                radius: corner_radii[2],
-                cx: offset_x as f32 + corner_radii[2],
-                cy: offset_y as f32 + eff_h as f32 - corner_radii[2],
-                is_top: false,
-                is_left: true,
-            },
-            Quadrant {
-                qx: offset_x + left_half_width,
-                qy: offset_y + top_half_height,
-                qw: right_half_width,
-                qh: bottom_half_height,
-                radius: corner_radii[3],
-                cx: offset_x as f32 + eff_w as f32 - corner_radii[3],
-                cy: offset_y as f32 + eff_h as f32 - corner_radii[3],
-                is_top: false,
-                is_left: false,
-            },
-        ];
-
-        for q in &quadrants {
-            if q.radius <= 0.0 {
-                continue;
+    Ok(NodeOp::Materialize {
+        label: "round_corners",
+        transform: Box::new(move |data, w, h, fmt| {
+            let width = *w;
+            let height = *h;
+            let bpp = fmt.bytes_per_pixel();
+            if width == 0 || height == 0 {
+                return;
             }
 
-            let radius_of_influence = q.radius + (1.0 - volumetric_offset);
-            let radius_of_solid = q.radius - volumetric_offset;
-            let alias_width = radius_of_influence - radius_of_solid;
-            let ri2 = radius_of_influence * radius_of_influence;
-            let rs2 = radius_of_solid * radius_of_solid;
+            let smallest = width.min(height) as f32;
 
-            let radius_ceil = q.radius.ceil() as u32;
+            // Resolve per-corner radii from mode + parameters.
+            // Returns [top_left, top_right, bottom_left, bottom_right] clamped to valid range.
+            let has_custom =
+                radius_tl >= 0.0 || radius_tr >= 0.0 || radius_bl >= 0.0 || radius_br >= 0.0;
+            let is_circle = mode == "circle";
+            let is_percentage = mode == "percentage" || mode == "percentage_custom";
 
-            let start_y = if q.is_top {
-                q.qy as usize
-            } else {
-                (q.qy + q.qh).saturating_sub(radius_ceil) as usize
-            };
-            let end_y = if q.is_top {
-                (q.qy as usize + radius_ceil as usize).min(q.qy as usize + q.qh as usize)
-            } else {
-                (q.qy + q.qh) as usize
-            };
-            let start_x = if q.is_left {
-                q.qx as usize
-            } else {
-                (q.qx + q.qw).saturating_sub(radius_ceil) as usize
-            };
-            let end_x = if q.is_left {
-                (q.qx as usize + radius_ceil as usize).min(q.qx as usize + q.qw as usize)
-            } else {
-                (q.qx + q.qw) as usize
-            };
-
-            // Clear edges for rows where the quadrant is not rendering an arc.
-            // This handles the non-arc rows in each quadrant that still need to be
-            // cleared outside the circle region (for non-zero offset scenarios).
-            let (clear_x_from, clear_x_to) = if q.is_left {
-                (0u32, q.qx)
-            } else {
-                (q.qx + q.qw, width)
-            };
-
-            if clear_x_from != clear_x_to {
-                // Rows in the quadrant above/below the arc range.
-                for y in (q.qy..start_y as u32).chain(end_y as u32..(q.qy + q.qh)) {
-                    let row_start = y as usize * width as usize * bpp;
-                    for x in clear_x_from as usize..clear_x_to as usize {
-                        let off = row_start + x * bpp;
-                        for c in 0..bpp.min(4) {
-                            data[off + c] = bg[c];
-                        }
-                    }
-                }
-            }
-
-            for y in start_y..end_y {
-                let yf = y as f32 + 0.5;
-                let y_dist = (q.cy - yf).abs();
-                let y_dist_sq = y_dist * y_dist;
-                let row_start = y * width as usize * bpp;
-
-                let x_dist_solid = (rs2 - y_dist_sq).max(0.0).sqrt();
-                let x_dist_influenced = (ri2 - y_dist_sq).max(0.0).sqrt();
-
-                let edge_solid_x1 = (q.cx - x_dist_solid).ceil().max(0.0) as usize;
-                let edge_solid_x2 = (q.cx + x_dist_solid).floor().min(width as f32) as usize;
-                let edge_influence_x1 = (q.cx - x_dist_influenced).floor().max(0.0) as usize;
-                let edge_influence_x2 =
-                    (q.cx + x_dist_influenced).ceil().min(width as f32) as usize;
-
-                // Clear what we don't need to alias (outside influence region).
-                if q.is_left {
-                    for x in start_x..edge_influence_x1.min(end_x) {
-                        let off = row_start + x * bpp;
-                        for c in 0..bpp.min(4) {
-                            data[off + c] = bg[c];
-                        }
-                    }
+            let corner_radii: [f32; 4] = if is_circle {
+                let r = smallest / 2.0;
+                [r, r, r, r]
+            } else if has_custom {
+                let tl = if radius_tl >= 0.0 { radius_tl } else { radius };
+                let tr = if radius_tr >= 0.0 { radius_tr } else { radius };
+                let bl = if radius_bl >= 0.0 { radius_bl } else { radius };
+                let br = if radius_br >= 0.0 { radius_br } else { radius };
+                if is_percentage {
+                    [
+                        smallest * tl.clamp(0.0, 100.0) / 200.0,
+                        smallest * tr.clamp(0.0, 100.0) / 200.0,
+                        smallest * bl.clamp(0.0, 100.0) / 200.0,
+                        smallest * br.clamp(0.0, 100.0) / 200.0,
+                    ]
                 } else {
-                    for x in edge_influence_x2.max(start_x)..end_x {
+                    let half = smallest / 2.0;
+                    [
+                        tl.clamp(0.0, half),
+                        tr.clamp(0.0, half),
+                        bl.clamp(0.0, half),
+                        br.clamp(0.0, half),
+                    ]
+                }
+            } else if is_percentage {
+                let r = smallest * radius.clamp(0.0, 100.0) / 200.0;
+                [r, r, r, r]
+            } else {
+                let r = radius.clamp(0.0, smallest / 2.0);
+                [r, r, r, r]
+            };
+
+            // Check if all radii are zero — nothing to do.
+            if corner_radii.iter().all(|&r| r <= 0.0) {
+                return;
+            }
+
+            // For circle mode on non-square canvases, compute offsets to center the circle.
+            // This matches V2's plan_quadrants Circle logic: the quadrants are offset so the
+            // circular region is centered in the larger dimension.
+            let (offset_x, offset_y) = if is_circle {
+                let ox = ((width as i64 - height as i64).max(0) / 2) as u32;
+                let oy = ((height as i64 - width as i64).max(0) / 2) as u32;
+                (ox, oy)
+            } else {
+                (0, 0)
+            };
+
+            // The effective canvas for quadrant computation (smallest dimension for circle).
+            let eff_w = if is_circle { smallest as u32 } else { width };
+            let eff_h = if is_circle { smallest as u32 } else { height };
+
+            // Integer division to avoid quadrant overlap on odd dimensions (matches V2).
+            let right_half_width = eff_w / 2;
+            let bottom_half_height = eff_h / 2;
+            let left_half_width = eff_w - right_half_width;
+            let top_half_height = eff_h - bottom_half_height;
+
+            // Volumetric offset: radius of a circle with the surface area of a 1x1 square.
+            let volumetric_offset: f32 = 0.56419; // sqrt(1/pi)
+
+            // Pre-convert bg color to linear space for gamma-correct blending.
+            let bg_linear: [f32; 4] = [
+                srgb_byte_to_linear(bg[0]),
+                srgb_byte_to_linear(bg[1]),
+                srgb_byte_to_linear(bg[2]),
+                bg[3] as f32 / 255.0,
+            ];
+
+            // Fill a rectangular region with the background color.
+            let fill_rect = |data: &mut [u8], x1: u32, y1: u32, x2: u32, y2: u32| {
+                let x1 = x1 as usize;
+                let y1 = y1 as usize;
+                let x2 = (x2 as usize).min(width as usize);
+                let y2 = (y2 as usize).min(height as usize);
+                for y in y1..y2 {
+                    let row_start = y * width as usize * bpp;
+                    for x in x1..x2 {
                         let off = row_start + x * bpp;
                         for c in 0..bpp.min(4) {
                             data[off + c] = bg[c];
                         }
                     }
                 }
+            };
 
-                // Alias pixels in the transition band.
-                let (alias_from, alias_to) = if q.is_left {
-                    (edge_influence_x1.max(start_x), edge_solid_x1.min(end_x))
+            // For circle mode: clear the top/bottom/left/right strips outside the circle region.
+            if is_circle {
+                // Clear top rows (above the circle region).
+                if offset_y > 0 {
+                    fill_rect(data, 0, 0, width, offset_y);
+                }
+                // Clear bottom rows (below the circle region).
+                let circle_bottom = offset_y + eff_h;
+                if circle_bottom < height {
+                    fill_rect(data, 0, circle_bottom, width, height);
+                }
+                // Clear left columns (left of the circle region) within the circle rows.
+                if offset_x > 0 {
+                    fill_rect(data, 0, offset_y, offset_x, offset_y + eff_h);
+                }
+                // Clear right columns (right of the circle region) within the circle rows.
+                let circle_right = offset_x + eff_w;
+                if circle_right < width {
+                    fill_rect(data, circle_right, offset_y, width, offset_y + eff_h);
+                }
+            }
+
+            // Quadrant definitions: [top_left, top_right, bottom_left, bottom_right]
+            // Each: (qx, qy, qw, qh, radius, center_x, center_y, is_top, is_left)
+            struct Quadrant {
+                qx: u32,
+                qy: u32,
+                qw: u32,
+                qh: u32,
+                radius: f32,
+                cx: f32,
+                cy: f32,
+                is_top: bool,
+                is_left: bool,
+            }
+
+            let quadrants = [
+                Quadrant {
+                    qx: offset_x,
+                    qy: offset_y,
+                    qw: left_half_width,
+                    qh: top_half_height,
+                    radius: corner_radii[0],
+                    cx: offset_x as f32 + corner_radii[0],
+                    cy: offset_y as f32 + corner_radii[0],
+                    is_top: true,
+                    is_left: true,
+                },
+                Quadrant {
+                    qx: offset_x + left_half_width,
+                    qy: offset_y,
+                    qw: right_half_width,
+                    qh: top_half_height,
+                    radius: corner_radii[1],
+                    cx: offset_x as f32 + eff_w as f32 - corner_radii[1],
+                    cy: offset_y as f32 + corner_radii[1],
+                    is_top: true,
+                    is_left: false,
+                },
+                Quadrant {
+                    qx: offset_x,
+                    qy: offset_y + top_half_height,
+                    qw: left_half_width,
+                    qh: bottom_half_height,
+                    radius: corner_radii[2],
+                    cx: offset_x as f32 + corner_radii[2],
+                    cy: offset_y as f32 + eff_h as f32 - corner_radii[2],
+                    is_top: false,
+                    is_left: true,
+                },
+                Quadrant {
+                    qx: offset_x + left_half_width,
+                    qy: offset_y + top_half_height,
+                    qw: right_half_width,
+                    qh: bottom_half_height,
+                    radius: corner_radii[3],
+                    cx: offset_x as f32 + eff_w as f32 - corner_radii[3],
+                    cy: offset_y as f32 + eff_h as f32 - corner_radii[3],
+                    is_top: false,
+                    is_left: false,
+                },
+            ];
+
+            for q in &quadrants {
+                if q.radius <= 0.0 {
+                    continue;
+                }
+
+                let radius_of_influence = q.radius + (1.0 - volumetric_offset);
+                let radius_of_solid = q.radius - volumetric_offset;
+                let alias_width = radius_of_influence - radius_of_solid;
+                let ri2 = radius_of_influence * radius_of_influence;
+                let rs2 = radius_of_solid * radius_of_solid;
+
+                let radius_ceil = q.radius.ceil() as u32;
+
+                let start_y = if q.is_top {
+                    q.qy as usize
                 } else {
-                    (edge_solid_x2.max(start_x), edge_influence_x2.min(end_x))
+                    (q.qy + q.qh).saturating_sub(radius_ceil) as usize
+                };
+                let end_y = if q.is_top {
+                    (q.qy as usize + radius_ceil as usize).min(q.qy as usize + q.qh as usize)
+                } else {
+                    (q.qy + q.qh) as usize
+                };
+                let start_x = if q.is_left {
+                    q.qx as usize
+                } else {
+                    (q.qx + q.qw).saturating_sub(radius_ceil) as usize
+                };
+                let end_x = if q.is_left {
+                    (q.qx as usize + radius_ceil as usize).min(q.qx as usize + q.qw as usize)
+                } else {
+                    (q.qx + q.qw) as usize
                 };
 
-                for x in alias_from..alias_to {
-                    let xf = x as f32 + 0.5;
-                    let diff_x = q.cx - xf;
-                    let distance = (diff_x * diff_x + y_dist_sq).sqrt();
+                // Clear edges for rows where the quadrant is not rendering an arc.
+                // This handles the non-arc rows in each quadrant that still need to be
+                // cleared outside the circle region (for non-zero offset scenarios).
+                let (clear_x_from, clear_x_to) = if q.is_left {
+                    (0u32, q.qx)
+                } else {
+                    (q.qx + q.qw, width)
+                };
 
-                    if distance > radius_of_influence {
-                        let off = row_start + x * bpp;
-                        for c in 0..bpp.min(4) {
-                            data[off + c] = bg[c];
-                        }
-                    } else if distance > radius_of_solid {
-                        let intensity = (distance - radius_of_solid) / alias_width;
-                        let off = row_start + x * bpp;
-
-                        let pixel_a = if bpp >= 4 {
-                            data[off + 3] as f32 / 255.0 * (1.0 - intensity)
-                        } else {
-                            1.0 - intensity
-                        };
-                        let matte_a = (1.0 - pixel_a) * bg_linear[3];
-                        let final_a = matte_a + pixel_a;
-
-                        if final_a > 0.0 {
-                            for c in 0..bpp.min(3) {
-                                let src_lin = srgb_byte_to_linear(data[off + c]);
-                                let blended =
-                                    (src_lin * pixel_a + bg_linear[c] * matte_a) / final_a;
-                                data[off + c] = linear_to_srgb_byte(blended);
-                            }
-                            if bpp >= 4 {
-                                data[off + 3] = (final_a * 255.0 + 0.5).min(255.0) as u8;
-                            }
-                        } else {
+                if clear_x_from != clear_x_to {
+                    // Rows in the quadrant above/below the arc range.
+                    for y in (q.qy..start_y as u32).chain(end_y as u32..(q.qy + q.qh)) {
+                        let row_start = y as usize * width as usize * bpp;
+                        for x in clear_x_from as usize..clear_x_to as usize {
+                            let off = row_start + x * bpp;
                             for c in 0..bpp.min(4) {
                                 data[off + c] = bg[c];
                             }
                         }
                     }
                 }
+
+                for y in start_y..end_y {
+                    let yf = y as f32 + 0.5;
+                    let y_dist = (q.cy - yf).abs();
+                    let y_dist_sq = y_dist * y_dist;
+                    let row_start = y * width as usize * bpp;
+
+                    let x_dist_solid = (rs2 - y_dist_sq).max(0.0).sqrt();
+                    let x_dist_influenced = (ri2 - y_dist_sq).max(0.0).sqrt();
+
+                    let edge_solid_x1 = (q.cx - x_dist_solid).ceil().max(0.0) as usize;
+                    let edge_solid_x2 = (q.cx + x_dist_solid).floor().min(width as f32) as usize;
+                    let edge_influence_x1 = (q.cx - x_dist_influenced).floor().max(0.0) as usize;
+                    let edge_influence_x2 =
+                        (q.cx + x_dist_influenced).ceil().min(width as f32) as usize;
+
+                    // Clear what we don't need to alias (outside influence region).
+                    if q.is_left {
+                        for x in start_x..edge_influence_x1.min(end_x) {
+                            let off = row_start + x * bpp;
+                            for c in 0..bpp.min(4) {
+                                data[off + c] = bg[c];
+                            }
+                        }
+                    } else {
+                        for x in edge_influence_x2.max(start_x)..end_x {
+                            let off = row_start + x * bpp;
+                            for c in 0..bpp.min(4) {
+                                data[off + c] = bg[c];
+                            }
+                        }
+                    }
+
+                    // Alias pixels in the transition band.
+                    let (alias_from, alias_to) = if q.is_left {
+                        (edge_influence_x1.max(start_x), edge_solid_x1.min(end_x))
+                    } else {
+                        (edge_solid_x2.max(start_x), edge_influence_x2.min(end_x))
+                    };
+
+                    for x in alias_from..alias_to {
+                        let xf = x as f32 + 0.5;
+                        let diff_x = q.cx - xf;
+                        let distance = (diff_x * diff_x + y_dist_sq).sqrt();
+
+                        if distance > radius_of_influence {
+                            let off = row_start + x * bpp;
+                            for c in 0..bpp.min(4) {
+                                data[off + c] = bg[c];
+                            }
+                        } else if distance > radius_of_solid {
+                            let intensity = (distance - radius_of_solid) / alias_width;
+                            let off = row_start + x * bpp;
+
+                            let pixel_a = if bpp >= 4 {
+                                data[off + 3] as f32 / 255.0 * (1.0 - intensity)
+                            } else {
+                                1.0 - intensity
+                            };
+                            let matte_a = (1.0 - pixel_a) * bg_linear[3];
+                            let final_a = matte_a + pixel_a;
+
+                            if final_a > 0.0 {
+                                for c in 0..bpp.min(3) {
+                                    let src_lin = srgb_byte_to_linear(data[off + c]);
+                                    let blended =
+                                        (src_lin * pixel_a + bg_linear[c] * matte_a) / final_a;
+                                    data[off + c] = linear_to_srgb_byte(blended);
+                                }
+                                if bpp >= 4 {
+                                    data[off + 3] = (final_a * 255.0 + 0.5).min(255.0) as u8;
+                                }
+                            } else {
+                                for c in 0..bpp.min(4) {
+                                    data[off + c] = bg[c];
+                                }
+                            }
+                        }
+                    }
+                }
             }
-        }
-    })})
+        }),
+    })
 }
 
 // ─── Linear/sRGB conversion helpers for gamma-correct blending ───

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1607,8 +1607,7 @@ impl PipelineGraph {
                 let meta = capture_meta!(upstream);
                 Ok((
                     Box::new(MaterializedSource::from_source_with_transform(
-                        upstream,
-                        transform,
+                        upstream, transform,
                     )?),
                     meta,
                 ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ pub use bridge::{OptimizationLevel, canonical_sort, optimize_node_order};
 #[cfg(feature = "zennode")]
 pub use orchestrate::{ProcessConfig, ProcessedImage, SourceImageInfo, StreamingOutput};
 
+// Re-export zencodecs quality types for callers resolving encode quality.
+pub use zencodecs::quality::{QualityIntent, QualityProfile};
+
 pub mod animation;
 pub mod codec;
 pub mod sidecar;


### PR DESCRIPTION
## Summary

Wire zencodecs' calibrated quality infrastructure into zenpipe's encode pipeline.

- `EncodeConfig::resolve_quality()` — parses string quality profiles to `QualityIntent` with per-codec calibrated lookups
- `EncodeConfig::resolve_profile()` — parses to `QualityProfile` enum
- DPR adjustment applied automatically (DPR 1.0 boosts quality for retina, 6.0 lowers for tiny pixels)
- Lossless override from `EncodeConfig.lossless`
- Re-exports `QualityIntent` and `QualityProfile` at crate root

Callers get `intent.jpeg_quality()`, `intent.webp_quality()`, `intent.jxl_distance()`, etc. instead of raw strings.

## Test plan

- [x] Named profiles ("good" → JPEG ~73, "high" → JPEG ~91)
- [x] Numeric profiles ("85" interpolates correctly)
- [x] DPR adjustment (1.0 boosts, 6.0 lowers)
- [x] Lossless override
- [x] Default resolution
- [x] 80 tests passing (16 new + 1 doctest)

Closes #4