### PR TITLE
feat: cost-aware format conversion via zenpixels-convert negotiate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,11 +53,11 @@ dependencies = [
 
 [[package]]
 name = "archmage"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31252c47e70c7056709e9f98842aef4f709056c2b3a4f666c584f8cc37f7ca0"
+checksum = "04abfbadff681a305ecd3db04ce891981aa9696d8c13058237e6a6417108fcfe"
 dependencies = [
- "archmage-macros 0.9.12",
+ "archmage-macros 0.9.13",
  "safe_unaligned_simd",
 ]
 
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "archmage-macros"
-version = "0.9.12"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a97189db9dffc2e13364c6f56461085d65743ff4d17890d6b80744203aae92b"
+checksum = "50a1d7ac60f40ab79a2b06f49d3863a4da7569ce8ed708c1eae163d30ce41d28"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -261,7 +261,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61ee8d8f5e43a45183480ea077c4e046e43ab9604928c87d6ad2080e666dc519"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "paste",
 ]
@@ -374,7 +374,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4b75067bc1e8c2c28413cab5777c0fe8473499e55f2e09076b9076f344ce9d5"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "magetypes",
  "num-traits",
@@ -401,7 +401,7 @@ version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c805c315148e092279cd19d011ce4b22ff9d3cc593cca089364f6501d12087b1"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
 ]
 
 [[package]]
@@ -799,7 +799,7 @@ name = "zenavif"
 version = "0.1.0"
 dependencies = [
  "almost-enough",
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "enough",
  "imgref",
@@ -847,7 +847,7 @@ dependencies = [
 name = "zenblend"
 version = "0.1.0"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "magetypes",
  "safe_unaligned_simd",
  "wide",
@@ -869,7 +869,7 @@ dependencies = [
 name = "zenfilters"
 version = "0.1.0"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "linear-srgb",
  "magetypes",
@@ -885,7 +885,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3ab3b331bb33391f2ac0a0716b5a5a06c634c3726f7a69b68d3052dbd2602f8"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "enough",
  "libm",
 ]
@@ -895,7 +895,7 @@ name = "zenflate"
 version = "0.3.2"
 source = "git+https://github.com/imazen/zenflate#67987f71379722e52106fca50e1717113e46d384"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "enough",
  "libm",
 ]
@@ -923,7 +923,7 @@ name = "zenjpeg"
 version = "0.6.1"
 dependencies = [
  "aligned-vec",
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "enough",
  "imgref",
@@ -1034,7 +1034,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15525e70fac3b3a6c2f7e3826c4e11376dd3ae885eaa7fe0aa252238381c3732"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "garb",
  "linear-srgb",
@@ -1049,7 +1049,7 @@ name = "zenpng"
 version = "0.1.0"
 dependencies = [
  "almost-enough",
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "bytemuck",
  "enough",
  "imgref",
@@ -1069,7 +1069,7 @@ dependencies = [
 name = "zenquant"
 version = "0.1.1"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "imgref",
  "linear-srgb",
  "magetypes",
@@ -1085,7 +1085,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88a5766f917b4a5e3321e7e64401fa3158e6db006996f83fb511b40f39b405cd"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "imgref",
  "linear-srgb",
  "magetypes",
@@ -1098,7 +1098,7 @@ dependencies = [
 name = "zenresize"
 version = "0.1.0"
 dependencies = [
- "archmage 0.9.12",
+ "archmage 0.9.13",
  "imgref",
  "libm",
  "linear-srgb",
@@ -1161,6 +1161,7 @@ version = "0.1.0"
 name = "zenwebp"
 version = "0.3.2"
 dependencies = [
+ "archmage 0.9.13",
  "bytemuck",
  "byteorder-lite",
  "enough",
@@ -1168,6 +1169,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "libm",
  "linear-srgb",
+ "magetypes",
  "self_cell",
  "thiserror",
  "whereat",

--- a/src/bridge/convert.rs
+++ b/src/bridge/convert.rs
@@ -358,329 +358,332 @@ pub(crate) fn convert_round_corners(node: &dyn NodeInstance) -> Result<NodeOp, P
         param_u32(node, "bg_a").unwrap_or(0) as u8,
     ];
 
-    Ok(NodeOp::Materialize { label: "round_corners", transform: Box::new(move |data, w, h, fmt| {
-        let width = *w;
-        let height = *h;
-        let bpp = fmt.bytes_per_pixel();
-        if width == 0 || height == 0 {
-            return;
-        }
-
-        let smallest = width.min(height) as f32;
-
-        // Resolve per-corner radii from mode + parameters.
-        // Returns [top_left, top_right, bottom_left, bottom_right] clamped to valid range.
-        let has_custom =
-            radius_tl >= 0.0 || radius_tr >= 0.0 || radius_bl >= 0.0 || radius_br >= 0.0;
-        let is_circle = mode == "circle";
-        let is_percentage = mode == "percentage" || mode == "percentage_custom";
-
-        let corner_radii: [f32; 4] = if is_circle {
-            let r = smallest / 2.0;
-            [r, r, r, r]
-        } else if has_custom {
-            let tl = if radius_tl >= 0.0 { radius_tl } else { radius };
-            let tr = if radius_tr >= 0.0 { radius_tr } else { radius };
-            let bl = if radius_bl >= 0.0 { radius_bl } else { radius };
-            let br = if radius_br >= 0.0 { radius_br } else { radius };
-            if is_percentage {
-                [
-                    smallest * tl.clamp(0.0, 100.0) / 200.0,
-                    smallest * tr.clamp(0.0, 100.0) / 200.0,
-                    smallest * bl.clamp(0.0, 100.0) / 200.0,
-                    smallest * br.clamp(0.0, 100.0) / 200.0,
-                ]
-            } else {
-                let half = smallest / 2.0;
-                [
-                    tl.clamp(0.0, half),
-                    tr.clamp(0.0, half),
-                    bl.clamp(0.0, half),
-                    br.clamp(0.0, half),
-                ]
-            }
-        } else if is_percentage {
-            let r = smallest * radius.clamp(0.0, 100.0) / 200.0;
-            [r, r, r, r]
-        } else {
-            let r = radius.clamp(0.0, smallest / 2.0);
-            [r, r, r, r]
-        };
-
-        // Check if all radii are zero — nothing to do.
-        if corner_radii.iter().all(|&r| r <= 0.0) {
-            return;
-        }
-
-        // For circle mode on non-square canvases, compute offsets to center the circle.
-        // This matches V2's plan_quadrants Circle logic: the quadrants are offset so the
-        // circular region is centered in the larger dimension.
-        let (offset_x, offset_y) = if is_circle {
-            let ox = ((width as i64 - height as i64).max(0) / 2) as u32;
-            let oy = ((height as i64 - width as i64).max(0) / 2) as u32;
-            (ox, oy)
-        } else {
-            (0, 0)
-        };
-
-        // The effective canvas for quadrant computation (smallest dimension for circle).
-        let eff_w = if is_circle { smallest as u32 } else { width };
-        let eff_h = if is_circle { smallest as u32 } else { height };
-
-        // Integer division to avoid quadrant overlap on odd dimensions (matches V2).
-        let right_half_width = eff_w / 2;
-        let bottom_half_height = eff_h / 2;
-        let left_half_width = eff_w - right_half_width;
-        let top_half_height = eff_h - bottom_half_height;
-
-        // Volumetric offset: radius of a circle with the surface area of a 1x1 square.
-        let volumetric_offset: f32 = 0.56419; // sqrt(1/pi)
-
-        // Pre-convert bg color to linear space for gamma-correct blending.
-        let bg_linear: [f32; 4] = [
-            srgb_byte_to_linear(bg[0]),
-            srgb_byte_to_linear(bg[1]),
-            srgb_byte_to_linear(bg[2]),
-            bg[3] as f32 / 255.0,
-        ];
-
-        // Fill a rectangular region with the background color.
-        let fill_rect = |data: &mut [u8], x1: u32, y1: u32, x2: u32, y2: u32| {
-            let x1 = x1 as usize;
-            let y1 = y1 as usize;
-            let x2 = (x2 as usize).min(width as usize);
-            let y2 = (y2 as usize).min(height as usize);
-            for y in y1..y2 {
-                let row_start = y * width as usize * bpp;
-                for x in x1..x2 {
-                    let off = row_start + x * bpp;
-                    for c in 0..bpp.min(4) {
-                        data[off + c] = bg[c];
-                    }
-                }
-            }
-        };
-
-        // For circle mode: clear the top/bottom/left/right strips outside the circle region.
-        if is_circle {
-            // Clear top rows (above the circle region).
-            if offset_y > 0 {
-                fill_rect(data, 0, 0, width, offset_y);
-            }
-            // Clear bottom rows (below the circle region).
-            let circle_bottom = offset_y + eff_h;
-            if circle_bottom < height {
-                fill_rect(data, 0, circle_bottom, width, height);
-            }
-            // Clear left columns (left of the circle region) within the circle rows.
-            if offset_x > 0 {
-                fill_rect(data, 0, offset_y, offset_x, offset_y + eff_h);
-            }
-            // Clear right columns (right of the circle region) within the circle rows.
-            let circle_right = offset_x + eff_w;
-            if circle_right < width {
-                fill_rect(data, circle_right, offset_y, width, offset_y + eff_h);
-            }
-        }
-
-        // Quadrant definitions: [top_left, top_right, bottom_left, bottom_right]
-        // Each: (qx, qy, qw, qh, radius, center_x, center_y, is_top, is_left)
-        struct Quadrant {
-            qx: u32,
-            qy: u32,
-            qw: u32,
-            qh: u32,
-            radius: f32,
-            cx: f32,
-            cy: f32,
-            is_top: bool,
-            is_left: bool,
-        }
-
-        let quadrants = [
-            Quadrant {
-                qx: offset_x,
-                qy: offset_y,
-                qw: left_half_width,
-                qh: top_half_height,
-                radius: corner_radii[0],
-                cx: offset_x as f32 + corner_radii[0],
-                cy: offset_y as f32 + corner_radii[0],
-                is_top: true,
-                is_left: true,
-            },
-            Quadrant {
-                qx: offset_x + left_half_width,
-                qy: offset_y,
-                qw: right_half_width,
-                qh: top_half_height,
-                radius: corner_radii[1],
-                cx: offset_x as f32 + eff_w as f32 - corner_radii[1],
-                cy: offset_y as f32 + corner_radii[1],
-                is_top: true,
-                is_left: false,
-            },
-            Quadrant {
-                qx: offset_x,
-                qy: offset_y + top_half_height,
-                qw: left_half_width,
-                qh: bottom_half_height,
-                radius: corner_radii[2],
-                cx: offset_x as f32 + corner_radii[2],
-                cy: offset_y as f32 + eff_h as f32 - corner_radii[2],
-                is_top: false,
-                is_left: true,
-            },
-            Quadrant {
-                qx: offset_x + left_half_width,
-                qy: offset_y + top_half_height,
-                qw: right_half_width,
-                qh: bottom_half_height,
-                radius: corner_radii[3],
-                cx: offset_x as f32 + eff_w as f32 - corner_radii[3],
-                cy: offset_y as f32 + eff_h as f32 - corner_radii[3],
-                is_top: false,
-                is_left: false,
-            },
-        ];
-
-        for q in &quadrants {
-            if q.radius <= 0.0 {
-                continue;
+    Ok(NodeOp::Materialize {
+        label: "round_corners",
+        transform: Box::new(move |data, w, h, fmt| {
+            let width = *w;
+            let height = *h;
+            let bpp = fmt.bytes_per_pixel();
+            if width == 0 || height == 0 {
+                return;
             }
 
-            let radius_of_influence = q.radius + (1.0 - volumetric_offset);
-            let radius_of_solid = q.radius - volumetric_offset;
-            let alias_width = radius_of_influence - radius_of_solid;
-            let ri2 = radius_of_influence * radius_of_influence;
-            let rs2 = radius_of_solid * radius_of_solid;
+            let smallest = width.min(height) as f32;
 
-            let radius_ceil = q.radius.ceil() as u32;
+            // Resolve per-corner radii from mode + parameters.
+            // Returns [top_left, top_right, bottom_left, bottom_right] clamped to valid range.
+            let has_custom =
+                radius_tl >= 0.0 || radius_tr >= 0.0 || radius_bl >= 0.0 || radius_br >= 0.0;
+            let is_circle = mode == "circle";
+            let is_percentage = mode == "percentage" || mode == "percentage_custom";
 
-            let start_y = if q.is_top {
-                q.qy as usize
-            } else {
-                (q.qy + q.qh).saturating_sub(radius_ceil) as usize
-            };
-            let end_y = if q.is_top {
-                (q.qy as usize + radius_ceil as usize).min(q.qy as usize + q.qh as usize)
-            } else {
-                (q.qy + q.qh) as usize
-            };
-            let start_x = if q.is_left {
-                q.qx as usize
-            } else {
-                (q.qx + q.qw).saturating_sub(radius_ceil) as usize
-            };
-            let end_x = if q.is_left {
-                (q.qx as usize + radius_ceil as usize).min(q.qx as usize + q.qw as usize)
-            } else {
-                (q.qx + q.qw) as usize
-            };
-
-            // Clear edges for rows where the quadrant is not rendering an arc.
-            // This handles the non-arc rows in each quadrant that still need to be
-            // cleared outside the circle region (for non-zero offset scenarios).
-            let (clear_x_from, clear_x_to) = if q.is_left {
-                (0u32, q.qx)
-            } else {
-                (q.qx + q.qw, width)
-            };
-
-            if clear_x_from != clear_x_to {
-                // Rows in the quadrant above/below the arc range.
-                for y in (q.qy..start_y as u32).chain(end_y as u32..(q.qy + q.qh)) {
-                    let row_start = y as usize * width as usize * bpp;
-                    for x in clear_x_from as usize..clear_x_to as usize {
-                        let off = row_start + x * bpp;
-                        for c in 0..bpp.min(4) {
-                            data[off + c] = bg[c];
-                        }
-                    }
-                }
-            }
-
-            for y in start_y..end_y {
-                let yf = y as f32 + 0.5;
-                let y_dist = (q.cy - yf).abs();
-                let y_dist_sq = y_dist * y_dist;
-                let row_start = y * width as usize * bpp;
-
-                let x_dist_solid = (rs2 - y_dist_sq).max(0.0).sqrt();
-                let x_dist_influenced = (ri2 - y_dist_sq).max(0.0).sqrt();
-
-                let edge_solid_x1 = (q.cx - x_dist_solid).ceil().max(0.0) as usize;
-                let edge_solid_x2 = (q.cx + x_dist_solid).floor().min(width as f32) as usize;
-                let edge_influence_x1 = (q.cx - x_dist_influenced).floor().max(0.0) as usize;
-                let edge_influence_x2 =
-                    (q.cx + x_dist_influenced).ceil().min(width as f32) as usize;
-
-                // Clear what we don't need to alias (outside influence region).
-                if q.is_left {
-                    for x in start_x..edge_influence_x1.min(end_x) {
-                        let off = row_start + x * bpp;
-                        for c in 0..bpp.min(4) {
-                            data[off + c] = bg[c];
-                        }
-                    }
+            let corner_radii: [f32; 4] = if is_circle {
+                let r = smallest / 2.0;
+                [r, r, r, r]
+            } else if has_custom {
+                let tl = if radius_tl >= 0.0 { radius_tl } else { radius };
+                let tr = if radius_tr >= 0.0 { radius_tr } else { radius };
+                let bl = if radius_bl >= 0.0 { radius_bl } else { radius };
+                let br = if radius_br >= 0.0 { radius_br } else { radius };
+                if is_percentage {
+                    [
+                        smallest * tl.clamp(0.0, 100.0) / 200.0,
+                        smallest * tr.clamp(0.0, 100.0) / 200.0,
+                        smallest * bl.clamp(0.0, 100.0) / 200.0,
+                        smallest * br.clamp(0.0, 100.0) / 200.0,
+                    ]
                 } else {
-                    for x in edge_influence_x2.max(start_x)..end_x {
+                    let half = smallest / 2.0;
+                    [
+                        tl.clamp(0.0, half),
+                        tr.clamp(0.0, half),
+                        bl.clamp(0.0, half),
+                        br.clamp(0.0, half),
+                    ]
+                }
+            } else if is_percentage {
+                let r = smallest * radius.clamp(0.0, 100.0) / 200.0;
+                [r, r, r, r]
+            } else {
+                let r = radius.clamp(0.0, smallest / 2.0);
+                [r, r, r, r]
+            };
+
+            // Check if all radii are zero — nothing to do.
+            if corner_radii.iter().all(|&r| r <= 0.0) {
+                return;
+            }
+
+            // For circle mode on non-square canvases, compute offsets to center the circle.
+            // This matches V2's plan_quadrants Circle logic: the quadrants are offset so the
+            // circular region is centered in the larger dimension.
+            let (offset_x, offset_y) = if is_circle {
+                let ox = ((width as i64 - height as i64).max(0) / 2) as u32;
+                let oy = ((height as i64 - width as i64).max(0) / 2) as u32;
+                (ox, oy)
+            } else {
+                (0, 0)
+            };
+
+            // The effective canvas for quadrant computation (smallest dimension for circle).
+            let eff_w = if is_circle { smallest as u32 } else { width };
+            let eff_h = if is_circle { smallest as u32 } else { height };
+
+            // Integer division to avoid quadrant overlap on odd dimensions (matches V2).
+            let right_half_width = eff_w / 2;
+            let bottom_half_height = eff_h / 2;
+            let left_half_width = eff_w - right_half_width;
+            let top_half_height = eff_h - bottom_half_height;
+
+            // Volumetric offset: radius of a circle with the surface area of a 1x1 square.
+            let volumetric_offset: f32 = 0.56419; // sqrt(1/pi)
+
+            // Pre-convert bg color to linear space for gamma-correct blending.
+            let bg_linear: [f32; 4] = [
+                srgb_byte_to_linear(bg[0]),
+                srgb_byte_to_linear(bg[1]),
+                srgb_byte_to_linear(bg[2]),
+                bg[3] as f32 / 255.0,
+            ];
+
+            // Fill a rectangular region with the background color.
+            let fill_rect = |data: &mut [u8], x1: u32, y1: u32, x2: u32, y2: u32| {
+                let x1 = x1 as usize;
+                let y1 = y1 as usize;
+                let x2 = (x2 as usize).min(width as usize);
+                let y2 = (y2 as usize).min(height as usize);
+                for y in y1..y2 {
+                    let row_start = y * width as usize * bpp;
+                    for x in x1..x2 {
                         let off = row_start + x * bpp;
                         for c in 0..bpp.min(4) {
                             data[off + c] = bg[c];
                         }
                     }
                 }
+            };
 
-                // Alias pixels in the transition band.
-                let (alias_from, alias_to) = if q.is_left {
-                    (edge_influence_x1.max(start_x), edge_solid_x1.min(end_x))
+            // For circle mode: clear the top/bottom/left/right strips outside the circle region.
+            if is_circle {
+                // Clear top rows (above the circle region).
+                if offset_y > 0 {
+                    fill_rect(data, 0, 0, width, offset_y);
+                }
+                // Clear bottom rows (below the circle region).
+                let circle_bottom = offset_y + eff_h;
+                if circle_bottom < height {
+                    fill_rect(data, 0, circle_bottom, width, height);
+                }
+                // Clear left columns (left of the circle region) within the circle rows.
+                if offset_x > 0 {
+                    fill_rect(data, 0, offset_y, offset_x, offset_y + eff_h);
+                }
+                // Clear right columns (right of the circle region) within the circle rows.
+                let circle_right = offset_x + eff_w;
+                if circle_right < width {
+                    fill_rect(data, circle_right, offset_y, width, offset_y + eff_h);
+                }
+            }
+
+            // Quadrant definitions: [top_left, top_right, bottom_left, bottom_right]
+            // Each: (qx, qy, qw, qh, radius, center_x, center_y, is_top, is_left)
+            struct Quadrant {
+                qx: u32,
+                qy: u32,
+                qw: u32,
+                qh: u32,
+                radius: f32,
+                cx: f32,
+                cy: f32,
+                is_top: bool,
+                is_left: bool,
+            }
+
+            let quadrants = [
+                Quadrant {
+                    qx: offset_x,
+                    qy: offset_y,
+                    qw: left_half_width,
+                    qh: top_half_height,
+                    radius: corner_radii[0],
+                    cx: offset_x as f32 + corner_radii[0],
+                    cy: offset_y as f32 + corner_radii[0],
+                    is_top: true,
+                    is_left: true,
+                },
+                Quadrant {
+                    qx: offset_x + left_half_width,
+                    qy: offset_y,
+                    qw: right_half_width,
+                    qh: top_half_height,
+                    radius: corner_radii[1],
+                    cx: offset_x as f32 + eff_w as f32 - corner_radii[1],
+                    cy: offset_y as f32 + corner_radii[1],
+                    is_top: true,
+                    is_left: false,
+                },
+                Quadrant {
+                    qx: offset_x,
+                    qy: offset_y + top_half_height,
+                    qw: left_half_width,
+                    qh: bottom_half_height,
+                    radius: corner_radii[2],
+                    cx: offset_x as f32 + corner_radii[2],
+                    cy: offset_y as f32 + eff_h as f32 - corner_radii[2],
+                    is_top: false,
+                    is_left: true,
+                },
+                Quadrant {
+                    qx: offset_x + left_half_width,
+                    qy: offset_y + top_half_height,
+                    qw: right_half_width,
+                    qh: bottom_half_height,
+                    radius: corner_radii[3],
+                    cx: offset_x as f32 + eff_w as f32 - corner_radii[3],
+                    cy: offset_y as f32 + eff_h as f32 - corner_radii[3],
+                    is_top: false,
+                    is_left: false,
+                },
+            ];
+
+            for q in &quadrants {
+                if q.radius <= 0.0 {
+                    continue;
+                }
+
+                let radius_of_influence = q.radius + (1.0 - volumetric_offset);
+                let radius_of_solid = q.radius - volumetric_offset;
+                let alias_width = radius_of_influence - radius_of_solid;
+                let ri2 = radius_of_influence * radius_of_influence;
+                let rs2 = radius_of_solid * radius_of_solid;
+
+                let radius_ceil = q.radius.ceil() as u32;
+
+                let start_y = if q.is_top {
+                    q.qy as usize
                 } else {
-                    (edge_solid_x2.max(start_x), edge_influence_x2.min(end_x))
+                    (q.qy + q.qh).saturating_sub(radius_ceil) as usize
+                };
+                let end_y = if q.is_top {
+                    (q.qy as usize + radius_ceil as usize).min(q.qy as usize + q.qh as usize)
+                } else {
+                    (q.qy + q.qh) as usize
+                };
+                let start_x = if q.is_left {
+                    q.qx as usize
+                } else {
+                    (q.qx + q.qw).saturating_sub(radius_ceil) as usize
+                };
+                let end_x = if q.is_left {
+                    (q.qx as usize + radius_ceil as usize).min(q.qx as usize + q.qw as usize)
+                } else {
+                    (q.qx + q.qw) as usize
                 };
 
-                for x in alias_from..alias_to {
-                    let xf = x as f32 + 0.5;
-                    let diff_x = q.cx - xf;
-                    let distance = (diff_x * diff_x + y_dist_sq).sqrt();
+                // Clear edges for rows where the quadrant is not rendering an arc.
+                // This handles the non-arc rows in each quadrant that still need to be
+                // cleared outside the circle region (for non-zero offset scenarios).
+                let (clear_x_from, clear_x_to) = if q.is_left {
+                    (0u32, q.qx)
+                } else {
+                    (q.qx + q.qw, width)
+                };
 
-                    if distance > radius_of_influence {
-                        let off = row_start + x * bpp;
-                        for c in 0..bpp.min(4) {
-                            data[off + c] = bg[c];
-                        }
-                    } else if distance > radius_of_solid {
-                        let intensity = (distance - radius_of_solid) / alias_width;
-                        let off = row_start + x * bpp;
-
-                        let pixel_a = if bpp >= 4 {
-                            data[off + 3] as f32 / 255.0 * (1.0 - intensity)
-                        } else {
-                            1.0 - intensity
-                        };
-                        let matte_a = (1.0 - pixel_a) * bg_linear[3];
-                        let final_a = matte_a + pixel_a;
-
-                        if final_a > 0.0 {
-                            for c in 0..bpp.min(3) {
-                                let src_lin = srgb_byte_to_linear(data[off + c]);
-                                let blended =
-                                    (src_lin * pixel_a + bg_linear[c] * matte_a) / final_a;
-                                data[off + c] = linear_to_srgb_byte(blended);
-                            }
-                            if bpp >= 4 {
-                                data[off + 3] = (final_a * 255.0 + 0.5).min(255.0) as u8;
-                            }
-                        } else {
+                if clear_x_from != clear_x_to {
+                    // Rows in the quadrant above/below the arc range.
+                    for y in (q.qy..start_y as u32).chain(end_y as u32..(q.qy + q.qh)) {
+                        let row_start = y as usize * width as usize * bpp;
+                        for x in clear_x_from as usize..clear_x_to as usize {
+                            let off = row_start + x * bpp;
                             for c in 0..bpp.min(4) {
                                 data[off + c] = bg[c];
                             }
                         }
                     }
                 }
+
+                for y in start_y..end_y {
+                    let yf = y as f32 + 0.5;
+                    let y_dist = (q.cy - yf).abs();
+                    let y_dist_sq = y_dist * y_dist;
+                    let row_start = y * width as usize * bpp;
+
+                    let x_dist_solid = (rs2 - y_dist_sq).max(0.0).sqrt();
+                    let x_dist_influenced = (ri2 - y_dist_sq).max(0.0).sqrt();
+
+                    let edge_solid_x1 = (q.cx - x_dist_solid).ceil().max(0.0) as usize;
+                    let edge_solid_x2 = (q.cx + x_dist_solid).floor().min(width as f32) as usize;
+                    let edge_influence_x1 = (q.cx - x_dist_influenced).floor().max(0.0) as usize;
+                    let edge_influence_x2 =
+                        (q.cx + x_dist_influenced).ceil().min(width as f32) as usize;
+
+                    // Clear what we don't need to alias (outside influence region).
+                    if q.is_left {
+                        for x in start_x..edge_influence_x1.min(end_x) {
+                            let off = row_start + x * bpp;
+                            for c in 0..bpp.min(4) {
+                                data[off + c] = bg[c];
+                            }
+                        }
+                    } else {
+                        for x in edge_influence_x2.max(start_x)..end_x {
+                            let off = row_start + x * bpp;
+                            for c in 0..bpp.min(4) {
+                                data[off + c] = bg[c];
+                            }
+                        }
+                    }
+
+                    // Alias pixels in the transition band.
+                    let (alias_from, alias_to) = if q.is_left {
+                        (edge_influence_x1.max(start_x), edge_solid_x1.min(end_x))
+                    } else {
+                        (edge_solid_x2.max(start_x), edge_influence_x2.min(end_x))
+                    };
+
+                    for x in alias_from..alias_to {
+                        let xf = x as f32 + 0.5;
+                        let diff_x = q.cx - xf;
+                        let distance = (diff_x * diff_x + y_dist_sq).sqrt();
+
+                        if distance > radius_of_influence {
+                            let off = row_start + x * bpp;
+                            for c in 0..bpp.min(4) {
+                                data[off + c] = bg[c];
+                            }
+                        } else if distance > radius_of_solid {
+                            let intensity = (distance - radius_of_solid) / alias_width;
+                            let off = row_start + x * bpp;
+
+                            let pixel_a = if bpp >= 4 {
+                                data[off + 3] as f32 / 255.0 * (1.0 - intensity)
+                            } else {
+                                1.0 - intensity
+                            };
+                            let matte_a = (1.0 - pixel_a) * bg_linear[3];
+                            let final_a = matte_a + pixel_a;
+
+                            if final_a > 0.0 {
+                                for c in 0..bpp.min(3) {
+                                    let src_lin = srgb_byte_to_linear(data[off + c]);
+                                    let blended =
+                                        (src_lin * pixel_a + bg_linear[c] * matte_a) / final_a;
+                                    data[off + c] = linear_to_srgb_byte(blended);
+                                }
+                                if bpp >= 4 {
+                                    data[off + 3] = (final_a * 255.0 + 0.5).min(255.0) as u8;
+                                }
+                            } else {
+                                for c in 0..bpp.min(4) {
+                                    data[off + c] = bg[c];
+                                }
+                            }
+                        }
+                    }
+                }
             }
-        }
-    })})
+        }),
+    })
 }
 
 // ─── Linear/sRGB conversion helpers for gamma-correct blending ───

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -627,16 +627,22 @@ impl PipelineGraph {
             NodeOp::Resize { w, h, .. } => {
                 let input_id = self.find_input(node_id, EdgeKind::Input)?;
                 let upstream = self.estimate_node(input_id, source_info, est, depth + 1)?;
+                // Cost-aware: f32 linear sources use ResizeF32Source (no u8 roundtrip).
+                let out_fmt = if upstream.format == format::RGBAF32_LINEAR {
+                    format::RGBAF32_LINEAR
+                } else {
+                    format::RGBA8_SRGB
+                };
                 // Resize ring buffer: kernel_height rows of input width
                 let kernel_rows = 16u64; // conservative for most filters
                 est.streaming_bytes +=
                     kernel_rows * upstream.width as u64 * upstream.format.bytes_per_pixel() as u64;
                 // Output strip buffer
-                est.streaming_bytes += strip_mem(*w, format::RGBA8_SRGB);
+                est.streaming_bytes += strip_mem(*w, out_fmt);
                 Ok(SourceInfo {
                     width: *w,
                     height: *h,
-                    format: format::RGBA8_SRGB,
+                    format: out_fmt,
                 })
             }
 
@@ -1099,6 +1105,7 @@ impl PipelineGraph {
         }
 
         /// Call ensure_format through the tracer (no-op recording when inactive).
+        /// Use for operations that require an exact format (MustBe).
         macro_rules! ensure_fmt {
             ($source:expr, $target:expr, $reason:expr) => {{
                 #[cfg(feature = "std")]
@@ -1108,6 +1115,24 @@ impl PipelineGraph {
                 #[cfg(not(feature = "std"))]
                 {
                     ensure_format($source, $target)
+                }
+            }};
+        }
+
+        /// Cost-aware format conversion via intent negotiation.
+        /// Uses [`ideal_format()`](zenpixels_convert::ideal_format) to pick the
+        /// cheapest compatible format instead of forcing a specific target.
+        /// If the source already satisfies the intent, no conversion is inserted.
+        #[allow(unused_macros)]
+        macro_rules! ensure_fmt_negotiated {
+            ($source:expr, $intent:expr, $reason:expr) => {{
+                #[cfg(feature = "std")]
+                {
+                    tracer.ensure_format_negotiated($source, $intent, $reason)
+                }
+                #[cfg(not(feature = "std"))]
+                {
+                    ensure_format_negotiated($source, $intent)
                 }
             }};
         }
@@ -1204,7 +1229,16 @@ impl PipelineGraph {
                 let input_id = self.find_input(node_id, EdgeKind::Input)?;
                 let upstream = self.compile_node(input_id, sources, depth + 1)?;
                 let meta = capture_meta!(upstream);
-                let upstream = ensure_fmt!(upstream, format::RGBA8_SRGB, "Resize")?;
+
+                // Cost-aware format selection: if upstream is already f32 linear
+                // (4 channels), use ResizeF32Source to avoid an unnecessary
+                // f32->u8->resize roundtrip. Otherwise convert to RGBA8_SRGB.
+                let use_f32 = upstream.format() == format::RGBAF32_LINEAR;
+                let upstream = if use_f32 {
+                    upstream
+                } else {
+                    ensure_fmt!(upstream, format::RGBA8_SRGB, "Resize")?
+                };
 
                 // Skip identity resize (same dimensions, no sharpening).
                 // ensure_format already ran, so format conversion is preserved.
@@ -1220,8 +1254,19 @@ impl PipelineGraph {
                 if let Some(pct) = sharpen_percent {
                     builder = builder.resize_sharpen(pct);
                 }
-                let config = builder.build();
-                Ok((Box::new(ResizeSource::new(upstream, &config, 16)?), meta))
+
+                if use_f32 {
+                    let config = builder
+                        .format(zenresize::PixelDescriptor::RGBAF32_LINEAR)
+                        .build();
+                    Ok((
+                        Box::new(crate::sources::ResizeF32Source::new(upstream, &config, 16)?),
+                        meta,
+                    ))
+                } else {
+                    let config = builder.build();
+                    Ok((Box::new(ResizeSource::new(upstream, &config, 16)?), meta))
+                }
             }
 
             NodeOp::Constrain {
@@ -1607,8 +1652,7 @@ impl PipelineGraph {
                 let meta = capture_meta!(upstream);
                 Ok((
                     Box::new(MaterializedSource::from_source_with_transform(
-                        upstream,
-                        transform,
+                        upstream, transform,
                     )?),
                     meta,
                 ))
@@ -1704,6 +1748,20 @@ fn ensure_format(
         ))
     })?;
     Ok(Box::new(TransformSource::new(source).push(op)))
+}
+
+/// Cost-aware format conversion using [`zenpixels_convert::ideal_format`] (no-std path).
+///
+/// Computes the ideal working format for the given intent and only converts
+/// if the source doesn't already satisfy the requirement.
+#[cfg(not(feature = "std"))]
+fn ensure_format_negotiated(
+    source: Box<dyn Source>,
+    intent: zenpixels_convert::ConvertIntent,
+) -> Result<Box<dyn Source>, PipeError> {
+    let current = source.format();
+    let ideal = zenpixels_convert::ideal_format(current, intent);
+    ensure_format(source, ideal)
 }
 
 // ensure_format_traced is now Tracer::ensure_format — see trace.rs

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -307,6 +307,10 @@ pub struct TraceEntry {
     /// Whether this node materializes (full-frame buffer).
     pub materializes: bool,
 
+    /// Two-axis conversion cost (effort + loss) for implicit format conversions.
+    /// `None` for explicit nodes and identity conversions.
+    pub conversion_cost: Option<zenpixels_convert::ConversionCost>,
+
     /// Runtime notes — content-adaptive decisions, detection results, etc.
     /// Populated during compilation for nodes like CropWhitespace, Analyze.
     pub notes: Vec<String>,
@@ -419,6 +423,7 @@ impl TraceAppender {
             output_width: w,
             output_height: h,
             materializes: false,
+            conversion_cost: None,
             notes: Vec::new(),
             #[cfg(feature = "std")]
             timing: None,
@@ -520,6 +525,7 @@ impl Tracer {
             output_width: source.width(),
             output_height: source.height(),
             materializes,
+            conversion_cost: None,
             notes: Vec::new(),
             timing: timing_arc.clone(),
         };
@@ -535,6 +541,9 @@ impl Tracer {
     ///
     /// When inactive, equivalent to a plain `ensure_format` — checks if conversion
     /// is needed and inserts a `RowConverterOp` if so. Zero allocations when inactive.
+    ///
+    /// Computes and records [`ConversionCost`](zenpixels_convert::ConversionCost)
+    /// (effort + loss) in the trace entry when tracing is active.
     pub fn ensure_format(
         &self,
         source: Box<dyn crate::Source>,
@@ -548,6 +557,8 @@ impl Tracer {
 
         let in_w = source.width();
         let in_h = source.height();
+
+        let cost = zenpixels_convert::conversion_cost(current, target);
 
         let op = crate::ops::RowConverterOp::new(current, target).ok_or_else(|| {
             crate::error::PipeError::Op(alloc::format!(
@@ -566,10 +577,12 @@ impl Tracer {
                 trace_order,
                 name: alloc::string::String::from("ConvertFormat"),
                 description: alloc::format!(
-                    "{} -> {} (for {})",
+                    "{} -> {} (for {}, effort={} loss={})",
                     format_short(&current),
                     format_short(&target),
-                    reason
+                    reason,
+                    cost.effort,
+                    cost.loss,
                 ),
                 origin: None,
                 implicit: true,
@@ -584,12 +597,32 @@ impl Tracer {
                 output_width: in_w,
                 output_height: in_h,
                 materializes: false,
+                conversion_cost: Some(cost),
                 notes: Vec::new(),
                 timing: None,
             });
         }
 
         Ok(result)
+    }
+
+    /// Cost-aware format conversion via [`zenpixels_convert::ideal_format`].
+    ///
+    /// Instead of forcing a specific target format, uses the intent to determine
+    /// the ideal working format for the downstream operation. If the source
+    /// already satisfies the intent (e.g., f32 linear source for a LinearLight
+    /// resize), no conversion is inserted — avoiding unnecessary round-trips.
+    ///
+    /// Falls back to `ensure_format` with the ideal target when conversion is needed.
+    pub fn ensure_format_negotiated(
+        &self,
+        source: Box<dyn crate::Source>,
+        intent: zenpixels_convert::ConvertIntent,
+        reason: &str,
+    ) -> Result<Box<dyn crate::Source>, crate::error::PipeError> {
+        let current = source.format();
+        let ideal = zenpixels_convert::ideal_format(current, intent);
+        self.ensure_format(source, ideal, reason)
     }
 
     /// Add a runtime note to the trace (e.g., content-adaptive detection results).
@@ -627,6 +660,7 @@ impl Tracer {
             output_width: output_w,
             output_height: output_h,
             materializes,
+            conversion_cost: None,
             notes: Vec::new(),
             timing: None,
         });
@@ -769,6 +803,13 @@ impl PipelineTrace {
             // Show origin (provenance) if present.
             if let Some(ref origin) = e.origin {
                 out.push_str(&format!("        origin: {origin}\n"));
+            }
+            // Show conversion cost for implicit format conversions.
+            if let Some(ref cost) = e.conversion_cost {
+                out.push_str(&format!(
+                    "        cost: effort={} loss={}\n",
+                    cost.effort, cost.loss
+                ));
             }
             // Show runtime notes indented below the entry.
             for note in &e.notes {

--- a/tests/cost_aware.rs
+++ b/tests/cost_aware.rs
@@ -1,0 +1,419 @@
+//! Tests for cost-aware format conversion (issue #5).
+//!
+//! Validates that the graph compiler uses `ideal_format()` / negotiate logic
+//! to avoid unnecessary format conversions, and that conversion costs are
+//! recorded in traces.
+
+use hashbrown::HashMap;
+
+use zenpipe::graph::{EdgeKind, NodeOp, PipelineGraph, SourceInfo};
+use zenpipe::sources::CallbackSource;
+use zenpipe::trace::TraceConfig;
+use zenpipe::{Source, format};
+
+/// Collect all strips from a source into a flat Vec<u8>.
+fn drain(source: &mut dyn Source) -> Vec<u8> {
+    let mut out = Vec::new();
+    while let Ok(Some(strip)) = source.next() {
+        out.extend_from_slice(strip.as_strided_bytes());
+    }
+    out
+}
+
+/// Create a solid-color RGBA8 sRGB source.
+fn solid_source(width: u32, height: u32, pixel: [u8; 4]) -> Box<dyn Source> {
+    let row_bytes = width as usize * 4;
+    let mut rows_produced = 0u32;
+    Box::new(CallbackSource::new(
+        width,
+        height,
+        format::RGBA8_SRGB,
+        16,
+        move |buf| {
+            if rows_produced >= height {
+                return Ok(false);
+            }
+            for px in buf[..row_bytes].chunks_exact_mut(4) {
+                px.copy_from_slice(&pixel);
+            }
+            rows_produced += 1;
+            Ok(true)
+        },
+    ))
+}
+
+/// Create a solid-color RGBA f32 linear source.
+fn solid_f32_linear_source(width: u32, height: u32, pixel: [f32; 4]) -> Box<dyn Source> {
+    let row_bytes = width as usize * 16; // 4 channels * 4 bytes/f32
+    let mut rows_produced = 0u32;
+    Box::new(CallbackSource::new(
+        width,
+        height,
+        format::RGBAF32_LINEAR,
+        16,
+        move |buf| {
+            if rows_produced >= height {
+                return Ok(false);
+            }
+            let f32_slice: &mut [f32] = bytemuck::cast_slice_mut(&mut buf[..row_bytes]);
+            for px in f32_slice.chunks_exact_mut(4) {
+                px.copy_from_slice(&pixel);
+            }
+            rows_produced += 1;
+            Ok(true)
+        },
+    ))
+}
+
+// ==========================================================================
+// Test: f32 linear source + Resize avoids u8 sRGB roundtrip
+// ==========================================================================
+
+#[test]
+fn resize_f32_linear_source_stays_f32() {
+    // When the source is already f32 linear, Resize should use ResizeF32Source
+    // instead of converting to u8 sRGB and back. The output format should
+    // remain RGBAF32_LINEAR.
+    let mut g = PipelineGraph::new();
+    let src = g.add_node(NodeOp::Source);
+    let resize = g.add_node(NodeOp::Resize {
+        w: 4,
+        h: 4,
+        filter: None,
+        sharpen_percent: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(src, resize, EdgeKind::Input);
+    g.add_edge(resize, out, EdgeKind::Input);
+
+    let mut sources = HashMap::new();
+    sources.insert(src, solid_f32_linear_source(8, 8, [0.5, 0.3, 0.1, 1.0]));
+
+    let mut pipeline = g.compile(sources).unwrap();
+    // Output should be f32 linear (not u8 sRGB)
+    assert_eq!(
+        pipeline.format(),
+        format::RGBAF32_LINEAR,
+        "f32 linear source should stay f32 after resize"
+    );
+    assert_eq!(pipeline.width(), 4);
+    assert_eq!(pipeline.height(), 4);
+
+    let data = drain(pipeline.as_mut());
+    let f32_data: &[f32] = bytemuck::cast_slice(&data);
+    // Verify we got valid f32 pixel data (not garbage)
+    for px in f32_data.chunks_exact(4) {
+        assert!(px[0] >= 0.0 && px[0] <= 1.0, "R out of range: {}", px[0]);
+        assert!(px[1] >= 0.0 && px[1] <= 1.0, "G out of range: {}", px[1]);
+        assert!(px[2] >= 0.0 && px[2] <= 1.0, "B out of range: {}", px[2]);
+        assert!(
+            (px[3] - 1.0).abs() < 0.01,
+            "A should be ~1.0, got {}",
+            px[3]
+        );
+    }
+}
+
+#[test]
+fn resize_f32_linear_traced_shows_no_conversion() {
+    // The traced version should show NO implicit ConvertFormat entry
+    // when the source is already f32 linear.
+    let mut g = PipelineGraph::new();
+    let src = g.add_node(NodeOp::Source);
+    let resize = g.add_node(NodeOp::Resize {
+        w: 4,
+        h: 4,
+        filter: None,
+        sharpen_percent: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(src, resize, EdgeKind::Input);
+    g.add_edge(resize, out, EdgeKind::Input);
+
+    let mut sources = HashMap::new();
+    sources.insert(src, solid_f32_linear_source(8, 8, [0.5, 0.3, 0.1, 1.0]));
+
+    let config = TraceConfig::metadata_only();
+    let (mut pipeline, trace) = g.compile_traced(sources, &config).unwrap();
+    assert_eq!(pipeline.format(), format::RGBAF32_LINEAR);
+
+    let _ = drain(pipeline.as_mut());
+
+    let trace = trace.lock().unwrap();
+    let implicit_conversions: Vec<_> = trace
+        .entries
+        .iter()
+        .filter(|e| e.implicit && e.name == "ConvertFormat")
+        .collect();
+    assert!(
+        implicit_conversions.is_empty(),
+        "f32 linear source should not trigger implicit format conversion for Resize, \
+         but found: {:?}",
+        implicit_conversions
+            .iter()
+            .map(|e| &e.description)
+            .collect::<Vec<_>>()
+    );
+}
+
+// ==========================================================================
+// Test: u8 sRGB source + Composite converts to f32 linear premul (required)
+// ==========================================================================
+
+#[test]
+fn composite_always_converts_to_premul_linear() {
+    // Composite MUST convert to RGBAF32_LINEAR_PREMUL regardless of source format.
+    let mut g = PipelineGraph::new();
+    let bg_src = g.add_node(NodeOp::Source);
+    let fg_src = g.add_node(NodeOp::Source);
+    let comp = g.add_node(NodeOp::Composite {
+        fg_x: 0,
+        fg_y: 0,
+        blend_mode: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(fg_src, comp, EdgeKind::Input);
+    g.add_edge(bg_src, comp, EdgeKind::Canvas);
+    g.add_edge(comp, out, EdgeKind::Input);
+
+    let mut sources = HashMap::new();
+    sources.insert(bg_src, solid_source(4, 4, [0, 0, 255, 255]));
+    sources.insert(fg_src, solid_source(4, 4, [255, 0, 0, 128]));
+
+    let config = TraceConfig::metadata_only();
+    let (mut pipeline, trace) = g.compile_traced(sources, &config).unwrap();
+    assert_eq!(pipeline.format(), format::RGBAF32_LINEAR_PREMUL);
+
+    let _ = drain(pipeline.as_mut());
+
+    // Verify implicit conversion was recorded with cost
+    let trace = trace.lock().unwrap();
+    let conversions: Vec<_> = trace
+        .entries
+        .iter()
+        .filter(|e| e.implicit && e.name == "ConvertFormat")
+        .collect();
+    assert!(
+        !conversions.is_empty(),
+        "Composite should insert implicit conversion from u8 sRGB"
+    );
+    // At least one conversion should have cost recorded
+    let has_cost = conversions.iter().any(|e| e.conversion_cost.is_some());
+    assert!(
+        has_cost,
+        "implicit conversions should record ConversionCost"
+    );
+}
+
+// ==========================================================================
+// Test: two adjacent ops with same format don't double-convert
+// ==========================================================================
+
+#[test]
+fn no_double_conversion_for_same_requirement() {
+    // Source(u8 sRGB) → Resize → Resize: only ONE conversion should happen
+    // (before the first Resize). The second Resize already has u8 input.
+    let mut g = PipelineGraph::new();
+    let src = g.add_node(NodeOp::Source);
+    let resize1 = g.add_node(NodeOp::Resize {
+        w: 6,
+        h: 6,
+        filter: None,
+        sharpen_percent: None,
+    });
+    let resize2 = g.add_node(NodeOp::Resize {
+        w: 4,
+        h: 4,
+        filter: None,
+        sharpen_percent: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(src, resize1, EdgeKind::Input);
+    g.add_edge(resize1, resize2, EdgeKind::Input);
+    g.add_edge(resize2, out, EdgeKind::Input);
+
+    let mut sources = HashMap::new();
+    sources.insert(src, solid_source(8, 8, [200, 100, 50, 255]));
+
+    let config = TraceConfig::metadata_only();
+    let (mut pipeline, trace) = g.compile_traced(sources, &config).unwrap();
+    assert_eq!(pipeline.format(), format::RGBA8_SRGB);
+
+    let _ = drain(pipeline.as_mut());
+
+    let trace = trace.lock().unwrap();
+    let conversions: Vec<_> = trace
+        .entries
+        .iter()
+        .filter(|e| e.implicit && e.name == "ConvertFormat")
+        .collect();
+    // Source is already RGBA8_SRGB, Resize wants RGBA8_SRGB → zero conversions
+    assert_eq!(
+        conversions.len(),
+        0,
+        "u8 sRGB source needs no conversion for Resize; got {} conversions: {:?}",
+        conversions.len(),
+        conversions
+            .iter()
+            .map(|e| &e.description)
+            .collect::<Vec<_>>()
+    );
+}
+
+// ==========================================================================
+// Test: tracing records conversion cost with effort and loss
+// ==========================================================================
+
+#[test]
+fn trace_records_conversion_cost() {
+    // Force a conversion (u8 sRGB → f32 linear premul via Composite)
+    // and verify the trace entry has conversion_cost with effort/loss.
+    let mut g = PipelineGraph::new();
+    let bg_src = g.add_node(NodeOp::Source);
+    let fg_src = g.add_node(NodeOp::Source);
+    let comp = g.add_node(NodeOp::Composite {
+        fg_x: 0,
+        fg_y: 0,
+        blend_mode: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(fg_src, comp, EdgeKind::Input);
+    g.add_edge(bg_src, comp, EdgeKind::Canvas);
+    g.add_edge(comp, out, EdgeKind::Input);
+
+    let mut sources = HashMap::new();
+    sources.insert(bg_src, solid_source(4, 4, [0, 0, 0, 255]));
+    sources.insert(fg_src, solid_source(4, 4, [255, 255, 255, 255]));
+
+    let config = TraceConfig::metadata_only();
+    let (mut pipeline, trace) = g.compile_traced(sources, &config).unwrap();
+    let _ = drain(pipeline.as_mut());
+
+    let trace = trace.lock().unwrap();
+    let conversion = trace
+        .entries
+        .iter()
+        .find(|e| e.implicit && e.name == "ConvertFormat")
+        .expect("should have at least one implicit conversion");
+
+    let cost = conversion
+        .conversion_cost
+        .expect("ConvertFormat entry should have conversion_cost");
+    // u8 sRGB → f32 linear premul has non-zero effort (transfer + depth change)
+    assert!(
+        cost.effort > 0,
+        "conversion from u8 sRGB to f32 linear premul should have non-zero effort, got {}",
+        cost.effort
+    );
+}
+
+// ==========================================================================
+// Test: estimate reflects f32 path for f32 linear source + Resize
+// ==========================================================================
+
+#[test]
+fn estimate_reflects_f32_resize_format() {
+    let mut g = PipelineGraph::new();
+    let src = g.add_node(NodeOp::Source);
+    let resize = g.add_node(NodeOp::Resize {
+        w: 4,
+        h: 4,
+        filter: None,
+        sharpen_percent: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(src, resize, EdgeKind::Input);
+    g.add_edge(resize, out, EdgeKind::Input);
+
+    let mut source_info = HashMap::new();
+    // f32 linear source
+    source_info.insert(
+        src,
+        SourceInfo {
+            width: 8,
+            height: 8,
+            format: format::RGBAF32_LINEAR,
+        },
+    );
+
+    let est = g.estimate(&source_info).unwrap();
+    assert_eq!(
+        est.output_format,
+        format::RGBAF32_LINEAR,
+        "estimate should reflect f32 output for f32 linear input"
+    );
+}
+
+#[test]
+fn estimate_reflects_u8_resize_format() {
+    let mut g = PipelineGraph::new();
+    let src = g.add_node(NodeOp::Source);
+    let resize = g.add_node(NodeOp::Resize {
+        w: 4,
+        h: 4,
+        filter: None,
+        sharpen_percent: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(src, resize, EdgeKind::Input);
+    g.add_edge(resize, out, EdgeKind::Input);
+
+    let mut source_info = HashMap::new();
+    // u8 sRGB source
+    source_info.insert(
+        src,
+        SourceInfo {
+            width: 8,
+            height: 8,
+            format: format::RGBA8_SRGB,
+        },
+    );
+
+    let est = g.estimate(&source_info).unwrap();
+    assert_eq!(
+        est.output_format,
+        format::RGBA8_SRGB,
+        "estimate should reflect u8 output for u8 sRGB input"
+    );
+}
+
+// ==========================================================================
+// Test: conversion cost description includes effort/loss in trace text
+// ==========================================================================
+
+#[test]
+fn trace_text_includes_cost_info() {
+    let mut g = PipelineGraph::new();
+    let bg_src = g.add_node(NodeOp::Source);
+    let fg_src = g.add_node(NodeOp::Source);
+    let comp = g.add_node(NodeOp::Composite {
+        fg_x: 0,
+        fg_y: 0,
+        blend_mode: None,
+    });
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(fg_src, comp, EdgeKind::Input);
+    g.add_edge(bg_src, comp, EdgeKind::Canvas);
+    g.add_edge(comp, out, EdgeKind::Input);
+
+    let mut sources = HashMap::new();
+    sources.insert(bg_src, solid_source(4, 4, [0, 0, 0, 255]));
+    sources.insert(fg_src, solid_source(4, 4, [255, 255, 255, 255]));
+
+    let config = TraceConfig::metadata_only();
+    let (mut pipeline, trace) = g.compile_traced(sources, &config).unwrap();
+    let _ = drain(pipeline.as_mut());
+
+    let trace = trace.lock().unwrap();
+    let text = trace.to_text();
+
+    // The trace text should include conversion cost info
+    assert!(
+        text.contains("effort=") && text.contains("loss="),
+        "trace text should include effort/loss cost info:\n{text}"
+    );
+    assert!(
+        text.contains("cost: effort="),
+        "trace text should include cost line:\n{text}"
+    );
+}


### PR DESCRIPTION
## Summary

Replace naive format forcing with cost-aware conversion decisions.

- **Resize stays f32 when source is f32 linear** — avoids f32→u8→resize→u8 roundtrip, uses `ResizeF32Source` directly
- **Conversion cost in traces** — `ConversionCost` (effort + loss) recorded on implicit conversion trace entries
- **`ensure_format_negotiated` infrastructure** — intent-based format selection via `ideal_format()` from zenpixels-convert (ready for future ops to adopt)
- **Estimate reflects actual format** — `estimate_node` for Resize reports f32 output when upstream is f32

## Test plan

- [x] f32 linear source stays f32 through resize (no unnecessary conversion)
- [x] Composite still forces premul linear (MustBe case preserved)
- [x] No double conversion for chained same-requirement ops
- [x] Trace records ConversionCost with non-zero effort
- [x] Estimate reflects correct format for both u8 and f32 inputs
- [x] to_text() includes cost info
- [x] 115 tests passing (8 new)

Closes #5