### PR TITLE
Add rotate_angle geometry node for arbitrary-angle rotation

### DIFF
--- a/src/bridge/geometry.rs
+++ b/src/bridge/geometry.rs
@@ -23,6 +23,7 @@ pub(crate) const GEOMETRY_SCHEMA_IDS: &[&str] = &[
     "zenlayout.rotate_90",
     "zenlayout.rotate_180",
     "zenlayout.rotate_270",
+    "zenlayout.rotate_angle",
     "zenresize.constrain",
     "zenlayout.constrain",
 ];
@@ -90,6 +91,21 @@ pub(crate) fn compile_geometry_run(
             }
             "zenlayout.rotate_270" => {
                 pipeline = pipeline.rotate_270();
+            }
+            "zenlayout.rotate_angle" => {
+                let degrees = super::parse::param_f32_opt(node, "degrees").unwrap_or(0.0);
+                let mode_str = node
+                    .get_param("mode")
+                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+                    .unwrap_or_default();
+                let mode = match mode_str.as_str() {
+                    "expand" => zenresize::RotateMode::Expand {
+                        color: zenresize::CanvasColor::Transparent,
+                    },
+                    "original" => zenresize::RotateMode::CropToOriginal,
+                    _ => zenresize::RotateMode::InscribedCrop,
+                };
+                pipeline = pipeline.rotate_angle(degrees, mode);
             }
             "zenresize.constrain" => {
                 let w = param_u32_opt(node, "w").filter(|&v| v > 0);


### PR DESCRIPTION
## Summary

Adds \`zenlayout.rotate_angle\` to the geometry fusion bridge. Accepts \`degrees\` (f32) and \`mode\` (crop/expand/original) parameters.

Delegates to \`Pipeline::rotate_angle()\` which handles cardinal vs non-cardinal dispatch automatically. Cardinal angles compose into D4 orientation (free). Non-cardinal angles produce a \`Command::Effect(RotateEffect)\` that the planner resolves with concrete dimensions.

## Dependencies

- imazen/zenlayout#4 — Pipeline refactor to \`Vec<Command>\` with \`.rotate_angle()\`
- imazen/zenresize#4 — Re-export \`RotateMode\`, \`CanvasColor\` etc.

## Note

zenpipe has a pre-existing build issue (\`zenavif\` version 0.1.3 local vs 0.1.13 required) that prevents full compilation. The geometry bridge change is minimal and mechanical — adding one match arm in \`compile_geometry_run()\`.

## Test plan

- [ ] Blocked on zenavif version — will test after version sync