### PR TITLE
fix: bound graph traversal depth and harden allocation arithmetic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ Cargo.toml.original.txt
 fuzz-*.log
 demo/crate/target-threaded/
 .claude/
+.workongoing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,9 +157,9 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
 name = "archmage"
-version = "0.9.19"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "365fca647ae78782eb112df49d25a3c6891c95f8a118eb942ea52a562e20d3df"
+checksum = "6e6248da30f2b6de70645c7af5b3658cf7d6dde8557a542efab62d21be13567d"
 dependencies = [
  "archmage-macros",
  "safe_unaligned_simd",
@@ -167,13 +167,13 @@ dependencies = [
 
 [[package]]
 name = "archmage-macros"
-version = "0.9.19"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f06d01d56dbc8b94d5d78f1dd71fcefaa131e2ab4daf6ffede59e28757dc6ff2"
+checksum = "0990742e24ab2b89d1b3623113cc474903d84151bef52e8b46d1ced2770c9ebb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -184,7 +184,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -246,7 +246,7 @@ checksum = "49c98dba06b920588de7d63f6acc23f1e6a9fade5fd6198e564506334fb5a4f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -325,6 +325,12 @@ dependencies = [
  "rustc-demangle",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
@@ -432,7 +438,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -526,7 +532,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -573,6 +579,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const_fn"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "constant_time_eq"
@@ -703,6 +715,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -710,7 +728,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -738,7 +756,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -758,7 +776,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -834,7 +852,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -922,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "garb"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ee8d8f5e43a45183480ea077c4e046e43ab9604928c87d6ad2080e666dc519"
+checksum = "ae3f56f280a24621bef5778559c4502d10136565311efa37a7b4ca257dce00ed"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -1252,7 +1270,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "time",
+ "time 0.3.47",
  "twox-hash",
  "unicase",
  "uuid",
@@ -1269,7 +1287,7 @@ dependencies = [
  "lazy_static",
  "macro-attr",
  "option-filter",
- "time",
+ "time 0.2.27",
  "url",
 ]
 
@@ -1330,7 +1348,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1410,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-encoder"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420865e6fca2f6682ad484e258ab8f36f8dc01ebf4cb39cb3e47490b5457e68"
+checksum = "0a2883a4596ba0212a4f005c29f55cc7d4e91603cc6574a91fe67338091849ac"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -1428,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "jxl-encoder-simd"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608869c437803761c5413fdb98b193e4a1ba56330cb62225337889758d8563f7"
+checksum = "f88c8baa7c73e9a4f7fdd58b9d996f2fef793416b4ea099f16adbe9b454e39f6"
 dependencies = [
  "archmage",
  "magetypes",
@@ -1693,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "linear-srgb"
-version = "0.6.10"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6579dbe611b00a07c95e561fc1751d91fb9f4b6d5445f7610c766a4efa155191"
+checksum = "fe0e61c33d85bc56dcaf27cdf48ca32b8e34af7236584eb1d8a47316c49e0be1"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -1746,9 +1764,9 @@ source = "git+https://github.com/DanielKeep/rust-custom-derive.git#1252f258cdb9b
 
 [[package]]
 name = "magetypes"
-version = "0.9.19"
+version = "0.9.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4ad2b56915b91b742a3bdd060ba4435ee92d60d4fc2087c4e6066bd4004434"
+checksum = "98970401ec6a338f1762c7986866ead4ab2257747cb0c247c29c0f0c3718b78e"
 dependencies = [
  "archmage",
 ]
@@ -1832,7 +1850,7 @@ checksum = "b093064383341eb3271f42e381cb8f10a01459478446953953c75d24bd339fc0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "target-features",
 ]
 
@@ -1941,9 +1959,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-derive"
@@ -1953,7 +1971,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2026,7 +2044,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2101,7 +2119,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2201,7 +2219,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2232,8 +2250,14 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -2260,7 +2284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52717f9a02b6965224f95ca2a81e2e0c5c43baacd28ca057577988930b6c3d5b"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2476,7 +2500,7 @@ dependencies = [
  "num",
  "num_enum",
  "rayon",
- "rustc_version",
+ "rustc_version 0.4.1",
  "serde",
  "thiserror 2.0.18",
  "toml 0.8.23",
@@ -2496,7 +2520,7 @@ dependencies = [
  "glob",
  "lazy_static",
  "rayon",
- "rustc_version",
+ "rustc_version 0.4.1",
  "toml 0.5.11",
 ]
 
@@ -2569,11 +2593,20 @@ checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -2630,9 +2663,24 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -2670,7 +2718,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2693,6 +2741,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
+dependencies = [
+ "sha1_smol",
 ]
 
 [[package]]
@@ -2746,6 +2803,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "standback"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
+name = "stdweb"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
+dependencies = [
+ "discard",
+ "rustc_version 0.2.3",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2769,7 +2884,18 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2791,7 +2917,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2850,7 +2976,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2861,7 +2987,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2899,9 +3025,24 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2912,9 +3053,32 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "tinystr"
@@ -3087,9 +3251,9 @@ checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
 name = "ultrahdr-core"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "964a038e0f75524ef9bd01ee6bda6d2457a3b6c1ca8df22478b9bb94b3547669"
+checksum = "1d65bd22a90785bb7360076b599ffbc201aef2c5817d2e5f37f37357829d476e"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -3099,6 +3263,9 @@ dependencies = [
  "magetypes",
  "thiserror 2.0.18",
  "wide",
+ "zencodec",
+ "zenpixels",
+ "zentone",
 ]
 
 [[package]]
@@ -3180,6 +3347,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,7 +3408,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -3279,7 +3452,7 @@ dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
- "semver",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -3393,7 +3566,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3404,7 +3577,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3610,7 +3783,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3626,7 +3799,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3660,7 +3833,7 @@ dependencies = [
  "id-arena",
  "indexmap",
  "log",
- "semver",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3699,7 +3872,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3749,8 +3922,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "zenanalyze"
+version = "0.1.0"
+dependencies = [
+ "archmage",
+ "garb",
+ "linear-srgb",
+ "magetypes",
+ "zenpixels",
+ "zenpixels-convert",
+]
+
+[[package]]
 name = "zenavif"
-version = "0.1.3"
+version = "0.1.6"
 dependencies = [
  "almost-enough",
  "archmage",
@@ -3766,7 +3951,7 @@ dependencies = [
  "thiserror 2.0.18",
  "whereat",
  "yuv",
- "zenavif-parse 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenavif-parse 0.6.1",
  "zencodec",
  "zenpixels",
  "zenpixels-convert",
@@ -3776,6 +3961,8 @@ dependencies = [
 [[package]]
 name = "zenavif-parse"
 version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecb456f6547bdbad2b24ec601bdd54a093874ddddc47d900b0edcc093de6e8ff"
 dependencies = [
  "arrayvec 0.7.6",
  "bitreader",
@@ -3789,9 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "zenavif-parse"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecb456f6547bdbad2b24ec601bdd54a093874ddddc47d900b0edcc093de6e8ff"
+version = "0.6.2"
 dependencies = [
  "arrayvec 0.7.6",
  "bitreader",
@@ -3828,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "zenbitmaps"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "enough",
  "imgref",
@@ -3840,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "zenblend"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "archmage",
  "magetypes",
@@ -3849,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "zenblend"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f495c5d65335f189f977cb2ecb25528d6e4e8b0cc0303e853f3ceb633e71187a"
+checksum = "d66daf1f95f9f3a3c7c4529ea1f993069e2691cc89a4f8b0f4002ced96179f68"
 dependencies = [
  "archmage",
  "magetypes",
@@ -3860,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "zencodec"
-version = "0.1.18"
+version = "0.1.20"
 dependencies = [
  "almost-enough",
  "enough",
@@ -3886,7 +4071,7 @@ dependencies = [
  "turbojpeg",
  "whereat",
  "zenavif",
- "zenavif-parse 0.6.1",
+ "zenavif-parse 0.6.2",
  "zenbitmaps",
  "zencodec",
  "zengif",
@@ -3895,7 +4080,7 @@ dependencies = [
  "zennode",
  "zenpixels",
  "zenpixels-convert",
- "zenpng",
+ "zenpng 0.1.4",
  "zenraw",
  "zensim-regress",
  "zenwebp",
@@ -3938,8 +4123,8 @@ dependencies = [
  "zennode",
  "zenpixels",
  "zenpixels-convert",
- "zenresize 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zensim 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenresize 0.2.2",
+ "zensim 0.2.6",
 ]
 
 [[package]]
@@ -3965,10 +4150,11 @@ dependencies = [
 
 [[package]]
 name = "zengif"
-version = "0.7.1"
+version = "0.7.3"
 dependencies = [
  "bytemuck",
  "enough",
+ "garb",
  "gif",
  "imagequant",
  "linear-srgb",
@@ -3989,6 +4175,7 @@ dependencies = [
  "archmage",
  "bytemuck",
  "enough",
+ "garb",
  "half",
  "imgref",
  "linear-srgb",
@@ -4000,15 +4187,16 @@ dependencies = [
  "tinyvec",
  "ultrahdr-core",
  "whereat",
- "yuv",
+ "zenanalyze",
  "zencodec",
  "zenpixels",
- "zenyuv 0.1.1",
+ "zentone",
+ "zenyuv 0.1.3",
 ]
 
 [[package]]
 name = "zenjxl"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "enough",
  "imgref",
@@ -4052,7 +4240,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4097,7 +4285,7 @@ version = "0.1.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4119,7 +4307,7 @@ dependencies = [
  "zenavif",
  "zenbench",
  "zenbitmaps",
- "zenblend 0.1.2",
+ "zenblend 0.1.3",
  "zencodec",
  "zencodecs",
  "zenfilters",
@@ -4130,9 +4318,9 @@ dependencies = [
  "zennode",
  "zenpixels",
  "zenpixels-convert",
- "zenpng",
+ "zenpng 0.1.4",
  "zenquant 0.1.2",
- "zenresize 0.2.2",
+ "zenresize 0.3.1",
  "zensally",
  "zensally-zentract",
  "zentiff",
@@ -4154,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "zenpixels"
-version = "0.2.8"
+version = "0.2.11"
 dependencies = [
  "bytemuck",
  "imgref",
@@ -4164,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "zenpixels-convert"
-version = "0.2.8"
+version = "0.2.11"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -4181,7 +4369,7 @@ dependencies = [
 
 [[package]]
 name = "zenpng"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "almost-enough",
  "archmage",
@@ -4189,6 +4377,8 @@ dependencies = [
  "enough",
  "imgref",
  "linear-srgb",
+ "magetypes",
+ "memchr",
  "rgb",
  "safe_unaligned_simd",
  "thiserror 2.0.18",
@@ -4198,6 +4388,39 @@ dependencies = [
  "zenpixels",
  "zenpixels-convert",
  "zenquant 0.1.3",
+]
+
+[[package]]
+name = "zenpng"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ef0ff0cfac28ce74a9241dbe8ba3abe60f385819d55675c4daced1ac8ac4bd"
+dependencies = [
+ "almost-enough",
+ "archmage",
+ "bytemuck",
+ "enough",
+ "imgref",
+ "linear-srgb",
+ "memchr",
+ "rgb",
+ "safe_unaligned_simd",
+ "thiserror 2.0.18",
+ "whereat",
+ "zencodec",
+ "zenflate 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenpixels",
+ "zenpixels-convert",
+]
+
+[[package]]
+name = "zenpredict"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "libm",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4230,9 +4453,9 @@ dependencies = [
 
 [[package]]
 name = "zenrav1e"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3a0480ad2ecd8da70dceb1d3b74dbe9e807992baccb52b33fa059692e317f7"
+checksum = "3c2f798defdace5a2d991e4f679697768cf256a3cef130bfa2d84702cebf3a76"
 dependencies = [
  "aligned-vec",
  "arbitrary",
@@ -4245,11 +4468,9 @@ dependencies = [
  "enough",
  "interpolate_name",
  "itertools",
- "libc",
  "libfuzzer-sys",
  "log",
  "maybe-rayon",
- "new_debug_unreachable",
  "noop_proc_macro",
  "num-derive",
  "num-traits",
@@ -4265,9 +4486,9 @@ dependencies = [
 
 [[package]]
 name = "zenravif"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95695202c3a6790c6811f6b5c3f0e0a3ea85dccb0ac1f4d6a24828c6e4bc08d8"
+checksum = "51edf23ff0690e4a7c3c7df67ee2143709f9bf33ecb8785cfffa33bba95ac314"
 dependencies = [
  "almost-enough",
  "imgref",
@@ -4280,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "zenraw"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -4299,22 +4520,6 @@ dependencies = [
 [[package]]
 name = "zenresize"
 version = "0.2.2"
-dependencies = [
- "archmage",
- "imgref",
- "libm",
- "linear-srgb",
- "magetypes",
- "rgb",
- "safe_unaligned_simd",
- "whereat",
- "zenblend 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zenpixels",
-]
-
-[[package]]
-name = "zenresize"
-version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f673b0b4c93ab1916c4804265e1ad9154de694ce5d3ce9f28a4ed8af4c259a24"
 dependencies = [
@@ -4326,8 +4531,42 @@ dependencies = [
  "rgb",
  "safe_unaligned_simd",
  "whereat",
- "zenblend 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenblend 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenlayout 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenpixels",
+]
+
+[[package]]
+name = "zenresize"
+version = "0.3.1"
+dependencies = [
+ "archmage",
+ "imgref",
+ "libm",
+ "linear-srgb",
+ "magetypes",
+ "rgb",
+ "safe_unaligned_simd",
+ "whereat",
+ "zenblend 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenpixels",
+]
+
+[[package]]
+name = "zenresize"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703679da7af627f10429532d0633b3d32fa0fd10d2b48ca94b5fcd0dbfd6e5a"
+dependencies = [
+ "archmage",
+ "imgref",
+ "libm",
+ "linear-srgb",
+ "magetypes",
+ "rgb",
+ "safe_unaligned_simd",
+ "whereat",
+ "zenblend 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "zenpixels",
 ]
 
@@ -4353,18 +4592,6 @@ dependencies = [
 [[package]]
 name = "zensim"
 version = "0.2.6"
-dependencies = [
- "archmage",
- "bytemuck",
- "linear-srgb",
- "magetypes",
- "rayon",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "zensim"
-version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd3fb9cea779ffee22e2045829cb126df4910f4026ca286f555cf42e9c4c295a"
 dependencies = [
@@ -4376,20 +4603,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "zensim"
+version = "0.2.7"
+dependencies = [
+ "archmage",
+ "bytemuck",
+ "linear-srgb",
+ "magetypes",
+ "rayon",
+ "thiserror 2.0.18",
+ "zenpredict",
+]
+
+[[package]]
 name = "zensim-regress"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "base64",
+ "bytemuck",
+ "enough",
  "fs2",
- "image",
+ "imgref",
+ "linear-srgb",
+ "rgb",
  "seahash",
  "thiserror 2.0.18",
- "zensim 0.2.6",
+ "zenblend 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenpixels",
+ "zenpng 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenresize 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zensim 0.2.7",
 ]
 
 [[package]]
 name = "zentiff"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "bytemuck",
  "enough",
@@ -4397,6 +4645,18 @@ dependencies = [
  "tiff 0.11.3",
  "whereat",
  "zenpixels",
+]
+
+[[package]]
+name = "zentone"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c602cc9010340287fd4ffcb2cd1ae9f6a665d37db59f0b9578352788cf8b304"
+dependencies = [
+ "archmage",
+ "libm",
+ "linear-srgb",
+ "magetypes",
 ]
 
 [[package]]
@@ -4416,7 +4676,7 @@ source = "git+https://github.com/imazen/zentract#6de10f8bfc563f773e89de716d318b2
 
 [[package]]
 name = "zenwebp"
-version = "0.4.3"
+version = "0.4.5"
 dependencies = [
  "archmage",
  "bytemuck",
@@ -4433,12 +4693,12 @@ dependencies = [
  "whereat",
  "zencodec",
  "zenpixels",
- "zenyuv 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zenyuv 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "zenyuv"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "archmage",
  "libm",
@@ -4449,9 +4709,9 @@ dependencies = [
 
 [[package]]
 name = "zenyuv"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889cc4d95b87392c0f01bce6815abd7648bf16b081f60e1122a30416c626b4f0"
+checksum = "6eca8f745696b57918b5529772fa7d0c112a07c86269277928bae2fd1d7aabae"
 dependencies = [
  "archmage",
  "libm",
@@ -4477,7 +4737,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4497,7 +4757,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4531,7 +4791,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4196,7 +4196,7 @@ dependencies = [
 
 [[package]]
 name = "zenjxl"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "enough",
  "imgref",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ nodes-all = [
 
 [dependencies]
 # Streaming resize (V-first, row push/pull, ring buffer)
-zenresize = { path = "../zenresize", default-features = false , version = "0.2.0" }
+zenresize = { path = "../zenresize", default-features = false , version = "0.3.1" }
 # Image layout: constraint modes, orientation, smart crop
 zenlayout = { workspace = true, features = ["smart-crop"] }
 # Blend modes on premultiplied linear f32 RGBA rows (SIMD-accelerated)
@@ -121,7 +121,7 @@ zenpng = { path = "../zenpng", default-features = false, features = ["zencodec"]
 zenwebp = { path = "../zenwebp", default-features = false, features = ["zencodec"], optional = true , version = "0.4.2" }
 zengif = { path = "../zengif", default-features = false, features = ["zencodec"], optional = true , version = "0.7.1" }
 zenavif = { path = "../zenavif", default-features = false, features = ["zencodec"], optional = true , version = "0.1.3" }
-zenjxl = { path = "../zenjxl", default-features = false, features = ["zencodec"], optional = true , version = "0.1.0" }
+zenjxl = { path = "../zenjxl", default-features = false, features = ["zencodec"], optional = true , version = "0.2.0" }
 zentiff = { path = "../zenextras/zentiff", default-features = false, optional = true , version = "0.1.0" }
 zenbitmaps = { path = "../zenbitmaps", default-features = false, optional = true , version = "0.1.3" }
 zenquant = { path = "../zenquant", default-features = false, optional = true , version = "0.1.2" }

--- a/examples/riapi_reference.rs
+++ b/examples/riapi_reference.rs
@@ -31,11 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     emit_footer(&mut out, &schemas)?;
 
     fs::write(&output_path, &out)?;
-    eprintln!(
-        "Wrote {} bytes to {}",
-        out.len(),
-        output_path
-    );
+    eprintln!("Wrote {} bytes to {}", out.len(), output_path);
     Ok(())
 }
 
@@ -58,7 +54,10 @@ fn emit_header(out: &mut Vec<u8>) -> std::io::Result<()> {
 
 fn emit_toc(out: &mut Vec<u8>, qs_keys: &Value) -> std::io::Result<()> {
     writeln!(out, "## Contents\n")?;
-    writeln!(out, "- [Querystring keys index](#querystring-keys-index) — flat list of every key")?;
+    writeln!(
+        out,
+        "- [Querystring keys index](#querystring-keys-index) — flat list of every key"
+    )?;
     writeln!(out, "- [Nodes](#nodes) — detailed reference per node")?;
 
     let nodes = qs_keys.get("nodes").and_then(|n| n.as_object());
@@ -79,10 +78,7 @@ fn emit_toc(out: &mut Vec<u8>, qs_keys: &Value) -> std::io::Result<()> {
 
 fn emit_all_keys_index(out: &mut Vec<u8>, qs_keys: &Value) -> std::io::Result<()> {
     writeln!(out, "## Querystring keys index\n")?;
-    writeln!(
-        out,
-        "| Key | Aliases | Node | Param | Type |"
-    )?;
+    writeln!(out, "| Key | Aliases | Node | Param | Type |")?;
     writeln!(out, "|---|---|---|---|---|")?;
 
     // Flatten: one row per (key, alias) pair, sorted.
@@ -95,10 +91,7 @@ fn emit_all_keys_index(out: &mut Vec<u8>, qs_keys: &Value) -> std::io::Result<()
                 None => continue,
             };
             for key_entry in keys {
-                let key = key_entry
-                    .get("key")
-                    .and_then(|k| k.as_str())
-                    .unwrap_or("?");
+                let key = key_entry.get("key").and_then(|k| k.as_str()).unwrap_or("?");
                 let param = key_entry
                     .get("param")
                     .and_then(|p| p.as_str())
@@ -123,7 +116,11 @@ fn emit_all_keys_index(out: &mut Vec<u8>, qs_keys: &Value) -> std::io::Result<()
                 let row = format!(
                     "| `{}` | {} | [`{}`](#{}) | `{}` | {} |",
                     key,
-                    if aliases.is_empty() { "—".into() } else { aliases },
+                    if aliases.is_empty() {
+                        "—".into()
+                    } else {
+                        aliases
+                    },
                     node_id,
                     anchor_for(node_id),
                     param,
@@ -180,7 +177,10 @@ fn emit_node_sections(
             }
         };
 
-        writeln!(out, "| Key | Aliases | Param | Type | Default | Description |")?;
+        writeln!(
+            out,
+            "| Key | Aliases | Param | Type | Default | Description |"
+        )?;
         writeln!(out, "|---|---|---|---|---|---|")?;
         for key_entry in keys {
             let key = key_entry.get("key").and_then(|k| k.as_str()).unwrap_or("?");
@@ -276,7 +276,10 @@ fn emit_enum_values(out: &mut Vec<u8>, schema: &Value) -> std::io::Result<()> {
     Ok(())
 }
 
-fn emit_footer(out: &mut Vec<u8>, schemas: &zenpipe::schema_export::ExportedSchemas) -> std::io::Result<()> {
+fn emit_footer(
+    out: &mut Vec<u8>,
+    schemas: &zenpipe::schema_export::ExportedSchemas,
+) -> std::io::Result<()> {
     let num_nodes = schemas
         .querystring_keys
         .get("nodes")

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -276,10 +276,15 @@ impl FrameSink {
         format: PixelFormat,
     ) -> Self {
         let stride = format.aligned_stride(width);
+        // Saturating fallback for the infallible-`new` ABI: try checked,
+        // and on overflow fall through to a zero-length buffer that the
+        // first frame copy will explicitly reject. New code should prefer
+        // the fallible variant.
+        let total = crate::limits::checked_stride_buffer(stride, height).unwrap_or(0);
         Self {
             encoder: Some(encoder),
             output: None,
-            frame_buf: vec![0u8; stride * height as usize],
+            frame_buf: vec![0u8; total],
             width,
             height,
             rows_accumulated: 0,
@@ -404,12 +409,75 @@ pub fn transcode(
     out_width: u32,
     out_height: u32,
     out_format: PixelFormat,
+    build_pipeline: impl FnMut(Box<dyn Source>, u32) -> crate::PipeResult<Box<dyn Source>>,
+) -> crate::PipeResult<EncodeOutput> {
+    transcode_with_stop_and_limits(
+        decoder,
+        encoder,
+        out_width,
+        out_height,
+        out_format,
+        build_pipeline,
+        &enough::Unstoppable,
+        None,
+    )
+}
+
+/// Like [`transcode`], but checks `stop` between frames and inside the
+/// per-frame pipeline (audit H8 / M6).
+pub fn transcode_with_stop(
+    decoder: Box<dyn DynAnimationFrameDecoder>,
+    encoder: Box<dyn DynAnimationFrameEncoder>,
+    out_width: u32,
+    out_height: u32,
+    out_format: PixelFormat,
+    build_pipeline: impl FnMut(Box<dyn Source>, u32) -> crate::PipeResult<Box<dyn Source>>,
+    stop: &dyn enough::Stop,
+) -> crate::PipeResult<EncodeOutput> {
+    transcode_with_stop_and_limits(
+        decoder,
+        encoder,
+        out_width,
+        out_height,
+        out_format,
+        build_pipeline,
+        stop,
+        None,
+    )
+}
+
+/// Full transcode entry point with cancellation and per-iteration frame-
+/// count enforcement (audit H8: decoders that lazily report `frame_count`
+/// can otherwise bypass the up-front `Limits::max_frames` check).
+pub fn transcode_with_stop_and_limits(
+    decoder: Box<dyn DynAnimationFrameDecoder>,
+    encoder: Box<dyn DynAnimationFrameEncoder>,
+    out_width: u32,
+    out_height: u32,
+    out_format: PixelFormat,
     mut build_pipeline: impl FnMut(Box<dyn Source>, u32) -> crate::PipeResult<Box<dyn Source>>,
+    stop: &dyn enough::Stop,
+    max_frames: Option<u32>,
 ) -> crate::PipeResult<EncodeOutput> {
     let mut frame_source = FrameSource::new(decoder)?;
     let mut frame_sink = FrameSink::new(encoder, out_width, out_height, out_format);
 
+    let mut frames_seen: u32 = 0;
     while let Some(info) = frame_source.frame_info() {
+        stop.check().map_err(|_| at!(PipeError::Cancelled))?;
+
+        // Per-iteration max_frames check — covers the case where the
+        // decoder's `frame_count()` returned `None` so the up-front check
+        // in `job::run` was skipped.
+        if let Some(max) = max_frames
+            && frames_seen >= max
+        {
+            return Err(at!(PipeError::LimitExceeded(alloc::format!(
+                "animation frame count exceeds max {max}"
+            ))));
+        }
+        frames_seen = frames_seen.saturating_add(1);
+
         // Build per-frame pipeline.
         // We need to give the pipeline a Source. Since FrameSource holds the
         // current frame data, we create a MemSource from its current state.
@@ -423,7 +491,7 @@ pub fn transcode(
 
         // Drain pipeline into frame sink.
         frame_sink.begin_frame();
-        crate::execute(pipeline.as_mut(), &mut frame_sink)?;
+        crate::execute_with_stop(pipeline.as_mut(), &mut frame_sink, stop)?;
         frame_sink.finish_frame(info.duration_ms)?;
 
         // Advance to next frame.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -62,15 +62,29 @@ impl<'a> DecoderSource<'a> {
                 let fmt = pixels.descriptor();
                 let rows = pixels.rows();
                 let bpp = fmt.bytes_per_pixel();
-                let row_bytes = w as usize * bpp;
+                let row_bytes = (w as usize).checked_mul(bpp).ok_or_else(|| {
+                    at!(PipeError::LimitExceeded(alloc::format!(
+                        "DecoderSource row_bytes overflow: w={w} bpp={bpp}"
+                    )))
+                })?;
+                let cap = (rows as usize).checked_mul(row_bytes).ok_or_else(|| {
+                    at!(PipeError::LimitExceeded(alloc::format!(
+                        "DecoderSource first_batch capacity overflow: rows={rows} row_bytes={row_bytes}"
+                    )))
+                })?;
 
                 // Copy first batch data for replay on first next() call.
-                let mut data = Vec::with_capacity(rows as usize * row_bytes);
+                let mut data = Vec::with_capacity(cap);
                 for r in 0..rows {
                     let row = pixels.row(r);
                     data.extend_from_slice(&row[..row_bytes]);
                 }
-                (fmt, Some((rows, data, row_bytes as u32)))
+                let row_bytes_u32 = u32::try_from(row_bytes).map_err(|_| {
+                    at!(PipeError::LimitExceeded(alloc::format!(
+                        "DecoderSource row_bytes {row_bytes} doesn't fit u32"
+                    )))
+                })?;
+                (fmt, Some((rows, data, row_bytes_u32)))
             }
             None => {
                 // Empty image — use a sensible default.
@@ -85,7 +99,7 @@ impl<'a> DecoderSource<'a> {
             width: w,
             height: h,
             format,
-            buf: StripBuf::new(w, sh, format),
+            buf: StripBuf::try_new(w, sh, format)?,
             first_batch,
             y: 0,
         })
@@ -108,7 +122,7 @@ impl<'a> DecoderSource<'a> {
             width: w,
             height: h,
             format,
-            buf: StripBuf::new(w, sh, format),
+            buf: StripBuf::try_new(w, sh, format)?,
             first_batch: None,
             y: 0,
         })

--- a/src/execute_layout.rs
+++ b/src/execute_layout.rs
@@ -8,13 +8,11 @@ use alloc::vec;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use zenresize::composite::{Background, CompositeError};
-use zenresize::{Filter, Resizer};
-use zenresize::{PixelDescriptor, AlphaMode, ChannelLayout, ChannelType};
-use zenlayout::{
-    CanvasColor, DecoderOffer, DecoderRequest, IdealLayout, LayoutPlan, Orientation,
-};
 use whereat::{At, ResultAtExt, at};
+use zenlayout::{CanvasColor, DecoderOffer, DecoderRequest, IdealLayout, LayoutPlan, Orientation};
+use zenresize::composite::{Background, CompositeError};
+use zenresize::{AlphaMode, ChannelLayout, ChannelType, PixelDescriptor};
+use zenresize::{Filter, Resizer};
 
 /// Bridge: convert zenlayout Orientation to zenresize OrientOutput.
 fn orient_from(o: Orientation) -> zenresize::OrientOutput {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -149,8 +149,19 @@ impl Default for ResourceEstimate {
 
 impl ResourceEstimate {
     /// Total worst-case peak memory (streaming + materialization).
+    ///
+    /// Saturating add — if a pathological graph pushes either accumulator
+    /// near `u64::MAX`, we return the saturated value rather than wrapping
+    /// (which would silently underflow the > comparison in `check`).
     pub fn peak_memory_bytes(&self) -> u64 {
-        self.streaming_bytes + self.materialization_bytes
+        self.streaming_bytes
+            .saturating_add(self.materialization_bytes)
+    }
+
+    /// Saturating add to `streaming_bytes`. Used internally so per-node
+    /// accumulators can't overflow u64 over a deep graph (audit M5).
+    pub(crate) fn add_streaming(&mut self, bytes: u64) {
+        self.streaming_bytes = self.streaming_bytes.saturating_add(bytes);
     }
 
     /// Check this estimate against resource limits.
@@ -1091,14 +1102,27 @@ impl PipelineGraph {
     }
 
     fn find_input(&self, node_id: NodeId, kind: EdgeKind) -> crate::PipeResult<NodeId> {
+        // Return an error if there are *multiple* edges of the same kind
+        // into this node (audit M4). validate() does not enforce per-kind
+        // cardinality, so a job that accidentally declared two Input edges
+        // would have silently dropped one in the previous code.
+        let mut found: Option<NodeId> = None;
         for e in &self.edges {
             if e.to == node_id && e.kind == kind {
-                return Ok(e.from);
+                if let Some(prev) = found {
+                    return Err(at!(PipeError::Op(alloc::format!(
+                        "node {node_id} has multiple {kind:?} input edges (from {prev} and {})",
+                        e.from
+                    ))));
+                }
+                found = Some(e.from);
             }
         }
-        Err(at!(PipeError::Op(alloc::format!(
-            "node {node_id} has no {kind:?} input edge"
-        ))))
+        found.ok_or_else(|| {
+            at!(PipeError::Op(alloc::format!(
+                "node {node_id} has no {kind:?} input edge"
+            )))
+        })
     }
 
     fn output_count(&self, node_id: NodeId) -> usize {
@@ -1238,11 +1262,8 @@ impl PipelineGraph {
                 let content_size = plan.content_size;
 
                 // Split effects by where they run relative to the resize step.
-                let (before_resize, after_resize): (Vec<_>, Vec<_>) = plan
-                    .effects
-                    .iter()
-                    .cloned()
-                    .partition(|e| e.before_resize);
+                let (before_resize, after_resize): (Vec<_>, Vec<_>) =
+                    plan.effects.iter().cloned().partition(|e| e.before_resize);
 
                 // Apply pre-resize effects (e.g. deskew at native resolution).
                 if !before_resize.is_empty() {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -961,9 +961,31 @@ impl PipelineGraph {
             } => {
                 let input_id = self.find_input(node_id, EdgeKind::Input)?;
                 let upstream = self.estimate_node(input_id, source_info, est, depth + 1)?;
+                // Use checked_add so an estimate that would wrap u32 is rejected
+                // before downstream limit checks see an undercount (audit H7).
+                let new_w = upstream
+                    .width
+                    .checked_add(*left)
+                    .and_then(|v| v.checked_add(*right))
+                    .ok_or_else(|| {
+                        at!(PipeError::LimitExceeded(alloc::format!(
+                            "ExpandCanvas estimate width overflow: w={} left={left} right={right}",
+                            upstream.width
+                        )))
+                    })?;
+                let new_h = upstream
+                    .height
+                    .checked_add(*top)
+                    .and_then(|v| v.checked_add(*bottom))
+                    .ok_or_else(|| {
+                        at!(PipeError::LimitExceeded(alloc::format!(
+                            "ExpandCanvas estimate height overflow: h={} top={top} bottom={bottom}",
+                            upstream.height
+                        )))
+                    })?;
                 Ok(SourceInfo {
-                    width: upstream.width + left + right,
-                    height: upstream.height + top + bottom,
+                    width: new_w,
+                    height: new_h,
                     format: upstream.format,
                 })
             }
@@ -1258,7 +1280,7 @@ impl PipelineGraph {
                     if cs.width < out_w || cs.height < out_h {
                         source = Box::new(EdgeReplicateSource::new(
                             source, cs.width, cs.height, out_w, out_h,
-                        ));
+                        )?);
                     }
                 }
 
@@ -1490,7 +1512,7 @@ impl PipelineGraph {
                     if cs.width < out_w || cs.height < out_h {
                         source = Box::new(EdgeReplicateSource::new(
                             source, cs.width, cs.height, out_w, out_h,
-                        ));
+                        )?);
                     }
                 }
 
@@ -1771,8 +1793,23 @@ impl PipelineGraph {
                 let meta = capture_meta!(upstream);
                 let src_w = upstream.width();
                 let src_h = upstream.height();
-                let canvas_w = src_w + left + right;
-                let canvas_h = src_h + top + bottom;
+                // Reject u32 wrap on canvas dim arithmetic (audit H7).
+                let canvas_w = src_w
+                    .checked_add(left)
+                    .and_then(|v| v.checked_add(right))
+                    .ok_or_else(|| {
+                        at!(PipeError::LimitExceeded(alloc::format!(
+                            "ExpandCanvas canvas width overflow: src_w={src_w} left={left} right={right}"
+                        )))
+                    })?;
+                let canvas_h = src_h
+                    .checked_add(top)
+                    .and_then(|v| v.checked_add(bottom))
+                    .ok_or_else(|| {
+                        at!(PipeError::LimitExceeded(alloc::format!(
+                            "ExpandCanvas canvas height overflow: src_h={src_h} top={top} bottom={bottom}"
+                        )))
+                    })?;
                 Ok((
                     Box::new(ExpandCanvasSource::new(
                         upstream,
@@ -1781,7 +1818,7 @@ impl PipelineGraph {
                         left as i32,
                         top as i32,
                         bg_color,
-                    )),
+                    )?),
                     meta,
                 ))
             }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -560,36 +560,64 @@ impl PipelineGraph {
             }
         }
 
-        // Cycle detection via DFS with coloring (white/gray/black)
-        // 0=white (unvisited), 1=gray (in progress), 2=black (done)
+        // Cycle detection via iterative DFS with coloring (white/gray/black).
+        // 0=white (unvisited), 1=gray (in progress), 2=black (done).
+        //
+        // Iterative — recursive DFS would blow the stack on a deep linear
+        // DAG (no MAX_GRAPH_DEPTH guard fires before the OS stack does on
+        // ~30k–100k linearly-chained nodes).
         let mut color = alloc::vec![0u8; self.nodes.len()];
         for start in 0..self.nodes.len() {
             if color[start] == 0 {
-                self.dfs_cycle_check(start, &mut color)?;
+                self.dfs_cycle_check_iter(start, &mut color)?;
             }
         }
 
         Ok(())
     }
 
-    /// DFS cycle detection. Traverses edges in reverse (to→from is our direction).
-    fn dfs_cycle_check(&self, node: usize, color: &mut [u8]) -> crate::PipeResult<()> {
-        color[node] = 1; // gray — in progress
-        // Follow edges where this node is the target (upstream nodes)
-        for e in &self.edges {
-            if e.to == node {
-                let upstream = e.from;
-                if color[upstream] == 1 {
-                    return Err(at!(PipeError::Op(alloc::format!(
-                        "cycle detected: node {upstream} → node {node}"
-                    ))));
+    /// Iterative DFS cycle detection. Traverses edges in reverse (to→from is
+    /// our direction). Uses an explicit work stack so the OS call stack stays
+    /// bounded regardless of graph depth.
+    fn dfs_cycle_check_iter(&self, start: usize, color: &mut [u8]) -> crate::PipeResult<()> {
+        // Each frame: (node, index_of_next_edge_to_examine).
+        // On first push, color[node] is set to 1 (gray); when the frame's
+        // edge-iteration completes, we pop and set color[node] = 2 (black).
+        let mut stack: alloc::vec::Vec<(usize, usize)> = alloc::vec::Vec::new();
+        color[start] = 1;
+        stack.push((start, 0));
+
+        while let Some((node, mut edge_idx)) = stack.pop() {
+            let mut advanced = false;
+            while edge_idx < self.edges.len() {
+                let e = &self.edges[edge_idx];
+                edge_idx += 1;
+                if e.to != node {
+                    continue;
                 }
-                if color[upstream] == 0 {
-                    self.dfs_cycle_check(upstream, color)?;
+                let upstream = e.from;
+                match color[upstream] {
+                    1 => {
+                        return Err(at!(PipeError::Op(alloc::format!(
+                            "cycle detected: node {upstream} → node {node}"
+                        ))));
+                    }
+                    0 => {
+                        // Save resumption point on this frame, then descend.
+                        stack.push((node, edge_idx));
+                        color[upstream] = 1;
+                        stack.push((upstream, 0));
+                        advanced = true;
+                        break;
+                    }
+                    _ => { /* black — already fully explored */ }
                 }
             }
+            if !advanced {
+                // All edges exhausted — mark this node black.
+                color[node] = 2;
+            }
         }
-        color[node] = 2; // black — done
         Ok(())
     }
 

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -243,6 +243,53 @@ impl Limits {
     }
 }
 
+/// Compute `width * height * bpp` as a `usize`, returning a
+/// [`PipeError::LimitExceeded`] on overflow (32-bit, wasm32, i686 are
+/// primary targets where this is reachable).
+///
+/// Use at every site that previously did `width as usize * height as usize
+/// * bpp` followed by `vec![0u8; n]`.
+pub fn checked_buffer_size(
+    width: u32,
+    height: u32,
+    bytes_per_pixel: usize,
+) -> crate::PipeResult<usize> {
+    let row = (width as usize)
+        .checked_mul(bytes_per_pixel)
+        .ok_or_else(|| {
+            at!(PipeError::LimitExceeded(alloc::format!(
+                "row size overflow: width {width} * bpp {bytes_per_pixel}"
+            )))
+        })?;
+    row.checked_mul(height as usize).ok_or_else(|| {
+        at!(PipeError::LimitExceeded(alloc::format!(
+            "buffer size overflow: row {row} * height {height}"
+        )))
+    })
+}
+
+/// Compute `stride * height` as a `usize`, returning a
+/// [`PipeError::LimitExceeded`] on overflow.
+pub fn checked_stride_buffer(stride: usize, height: u32) -> crate::PipeResult<usize> {
+    stride.checked_mul(height as usize).ok_or_else(|| {
+        at!(PipeError::LimitExceeded(alloc::format!(
+            "buffer size overflow: stride {stride} * height {height}"
+        )))
+    })
+}
+
+/// Compute `a + b` as `u32`, returning a [`PipeError::LimitExceeded`] on overflow.
+///
+/// Use for dimension addition (canvas geometry, crop offsets, etc.) where
+/// silent wrap would produce a smaller dimension that bypasses limit checks.
+pub fn checked_dim_add(a: u32, b: u32) -> crate::PipeResult<u32> {
+    a.checked_add(b).ok_or_else(|| {
+        at!(PipeError::LimitExceeded(alloc::format!(
+            "dimension overflow: {a} + {b} > u32::MAX"
+        )))
+    })
+}
+
 // =========================================================================
 // AllocationTracker — runtime memory accounting
 // =========================================================================
@@ -319,10 +366,59 @@ impl AllocationTracker {
     /// push `current_bytes` past the configured limit.
     ///
     /// The returned [`AllocationGuard`] decrements `current_bytes` on drop.
+    ///
+    /// Atomic check-and-add via `compare_exchange`: when multiple threads
+    /// race, at most one wins for any given budget; losers retry against
+    /// the updated current total or surface a limit error.
     pub fn allocate(self: &Arc<Self>, bytes: u64) -> crate::PipeResult<AllocationGuard> {
-        self.check(bytes)?;
+        let new_total = if self.limit_bytes > 0 {
+            let mut current = self.current_bytes.load(Ordering::Acquire);
+            loop {
+                let candidate = current.checked_add(bytes).ok_or_else(|| {
+                    at!(PipeError::LimitExceeded(alloc::format!(
+                        "memory: requested {bytes} bytes overflows u64 (current {current})"
+                    )))
+                })?;
+                if candidate > self.limit_bytes {
+                    return Err(at!(PipeError::LimitExceeded(alloc::format!(
+                        "memory: {} + {} = {} bytes exceeds limit {}",
+                        current,
+                        bytes,
+                        candidate,
+                        self.limit_bytes,
+                    ))));
+                }
+                match self.current_bytes.compare_exchange_weak(
+                    current,
+                    candidate,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break candidate,
+                    Err(actual) => current = actual,
+                }
+            }
+        } else {
+            // Unlimited: still need overflow protection on the running total.
+            let mut current = self.current_bytes.load(Ordering::Acquire);
+            loop {
+                let candidate = current.checked_add(bytes).ok_or_else(|| {
+                    at!(PipeError::LimitExceeded(alloc::format!(
+                        "memory: requested {bytes} bytes overflows u64 (current {current})"
+                    )))
+                })?;
+                match self.current_bytes.compare_exchange_weak(
+                    current,
+                    candidate,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => break candidate,
+                    Err(actual) => current = actual,
+                }
+            }
+        };
 
-        let new_total = self.current_bytes.fetch_add(bytes, Ordering::SeqCst) + bytes;
         self.peak_bytes.fetch_max(new_total, Ordering::SeqCst);
         self.allocation_count.fetch_add(1, Ordering::SeqCst);
 
@@ -339,16 +435,23 @@ impl AllocationTracker {
     }
 
     /// Check whether `requested` bytes can be allocated without exceeding
-    /// the limit. Does **not** actually allocate.
+    /// the limit. Does **not** actually allocate, and is therefore subject
+    /// to TOCTOU under concurrency — prefer [`allocate()`](Self::allocate)
+    /// when you intend to acquire the bytes.
     pub fn check(&self, requested: u64) -> crate::PipeResult<()> {
         if self.limit_bytes > 0 {
             let current = self.current_bytes.load(Ordering::SeqCst);
-            if current + requested > self.limit_bytes {
+            let candidate = current.checked_add(requested).ok_or_else(|| {
+                at!(PipeError::LimitExceeded(alloc::format!(
+                    "memory: requested {requested} bytes overflows u64 (current {current})"
+                )))
+            })?;
+            if candidate > self.limit_bytes {
                 return Err(at!(PipeError::LimitExceeded(alloc::format!(
                     "memory: {} + {} = {} bytes exceeds limit {}",
                     current,
                     requested,
-                    current + requested,
+                    candidate,
                     self.limit_bytes,
                 ))));
             }

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -149,13 +149,15 @@ impl MatteFlattenOp {
 }
 
 impl PixelOp for MatteFlattenOp {
-    fn apply(&mut self, input: &[u8], output: &mut [u8], width: u32, height: u32) {
-        let n = width as usize * height as usize;
-        for i in 0..n {
-            let p = &input[i * 4..i * 4 + 4];
+    fn apply(&mut self, input: &[u8], output: &mut [u8], _width: u32, _height: u32) {
+        // Iterate by chunks_exact — let the slice length bound the loop
+        // rather than computing `width * height` (which overflows on
+        // 32-bit for large dims, audit M7).
+        let inputs = input.chunks_exact(4);
+        let outputs = output.chunks_exact_mut(3);
+        for (p, o) in inputs.zip(outputs) {
             let a = p[3] as u32;
             let inv = 255 - a;
-            let o = &mut output[i * 3..i * 3 + 3];
             for c in 0..3 {
                 o[c] = ((p[c] as u32 * a + self.matte[c] as u32 * inv + 127) / 255) as u8;
             }
@@ -192,10 +194,13 @@ impl ScaleAlphaOp {
 }
 
 impl PixelOp for ScaleAlphaOp {
-    fn apply(&mut self, input: &[u8], output: &mut [u8], width: u32, height: u32) {
+    fn apply(&mut self, input: &[u8], output: &mut [u8], _width: u32, _height: u32) {
+        // Bound by slice lengths (audit M7) — width*height*4 wraps on
+        // 32-bit for large dims, and bytemuck::cast_slice already returns
+        // a slice whose length matches the byte buffer.
         let in_f32: &[f32] = bytemuck::cast_slice(input);
         let out_f32: &mut [f32] = bytemuck::cast_slice_mut(output);
-        let len = width as usize * height as usize * 4;
+        let len = in_f32.len().min(out_f32.len());
         for i in 0..len {
             out_f32[i] = in_f32[i] * self.opacity;
         }

--- a/src/orchestrate.rs
+++ b/src/orchestrate.rs
@@ -51,8 +51,8 @@ use crate::format::PixelFormat;
 use crate::sidecar::{ProcessedSidecar, SidecarPlan, SidecarStream};
 use crate::sources::MaterializedSource;
 
-use zenresize::Filter;
 use zenlayout::Size;
+use zenresize::Filter;
 
 // ─── Configuration ───
 

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -19,8 +19,8 @@ use crate::graph::{EdgeKind, NodeOp, PipelineGraph};
 use crate::sources::MaterializedSource;
 
 use zencodec::GainMapParams;
-use zenresize::Filter;
 use zenlayout::{DecoderOffer, DecoderRequest, IdealLayout, LayoutPlan, Orientation, Size};
+use zenresize::Filter;
 
 /// What kind of auxiliary data the sidecar carries.
 #[derive(Clone, Debug)]

--- a/src/sources/composite.rs
+++ b/src/sources/composite.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::vec;
+use alloc::vec::Vec;
 
 use crate::Source;
 #[allow(unused_imports)]
@@ -27,6 +28,8 @@ pub struct CompositeSource {
     height: u32,
     strip_height: u32,
     buf: StripBuf,
+    /// Reusable per-row composite buffer (pre-allocated; was per-row alloc).
+    composite_row_buf: Vec<u8>,
     y: u32,
     blend_mode: zenblend::BlendMode,
 }
@@ -73,6 +76,8 @@ impl CompositeSource {
         let h = background.height();
         let fg_h = foreground.height();
         let sh = 16u32.min(h);
+        let buf = StripBuf::try_new(w, sh, fmt)?;
+        let stride = buf.stride();
 
         Ok(Self {
             background,
@@ -83,7 +88,8 @@ impl CompositeSource {
             width: w,
             height: h,
             strip_height: sh,
-            buf: StripBuf::new(w, sh, fmt),
+            buf,
+            composite_row_buf: vec![0u8; stride],
             y: 0,
             blend_mode: zenblend::BlendMode::SrcOver,
         })
@@ -98,8 +104,14 @@ impl Source for CompositeSource {
 
         let rows_wanted = self.strip_height.min(self.height - self.y);
         self.buf
-            .reconfigure(self.width, rows_wanted, format::RGBAF32_LINEAR_PREMUL);
+            .try_reconfigure(self.width, rows_wanted, format::RGBAF32_LINEAR_PREMUL)?;
         self.buf.reset();
+
+        // Ensure the reusable composite row keeps up with stride changes.
+        let stride = self.buf.stride();
+        if self.composite_row_buf.len() < stride {
+            self.composite_row_buf.resize(stride, 0);
+        }
 
         // Pull background strip
         let bg_strip = self.background.next()?;
@@ -107,9 +119,11 @@ impl Source for CompositeSource {
             return Ok(None);
         };
 
-        // Check if foreground overlaps this strip's y range
-        let strip_y_end = self.y + bg_strip.rows();
-        let fg_overlaps = self.y < self.fg_y + self.fg_h && strip_y_end > self.fg_y;
+        // Check if foreground overlaps this strip's y range (saturating —
+        // u32 add wrap could otherwise push the comparison out of bounds).
+        let strip_y_end = self.y.saturating_add(bg_strip.rows());
+        let fg_y_end = self.fg_y.saturating_add(self.fg_h);
+        let fg_overlaps = self.y < fg_y_end && strip_y_end > self.fg_y;
 
         if !fg_overlaps {
             // No foreground — pass through background
@@ -121,28 +135,26 @@ impl Source for CompositeSource {
             let fg_strip = self.foreground.next()?;
 
             for r in 0..bg_strip.rows() {
-                let abs_y = self.y + r;
+                let abs_y = self.y.saturating_add(r);
                 let bg_row = bg_strip.row(r);
 
-                let has_fg =
-                    abs_y >= self.fg_y && abs_y < self.fg_y + self.fg_h && fg_strip.is_some();
+                let has_fg = abs_y >= self.fg_y && abs_y < fg_y_end && fg_strip.is_some();
 
                 if has_fg {
                     let fg = fg_strip.as_ref().unwrap();
                     let fg_local_y = abs_y - self.fg_y;
                     if fg_local_y < fg.rows() {
                         let fg_row = fg.row(fg_local_y);
-                        let stride = self.buf.stride();
-                        let mut out_row = vec![0u8; stride];
+                        let out_row = &mut self.composite_row_buf[..stride];
                         composite_row_over(
                             bg_row,
                             fg_row,
-                            &mut out_row,
+                            out_row,
                             self.fg_x as usize,
                             self.width as usize,
                             self.blend_mode,
-                        );
-                        self.buf.push_row(&out_row);
+                        )?;
+                        self.buf.push_row(out_row);
                         continue;
                     }
                 }
@@ -167,6 +179,9 @@ impl Source for CompositeSource {
 }
 
 /// Blend one row: fg placed at `fg_x_offset` within bg, result written to out.
+///
+/// Validates that bg/fg/out byte lengths are multiples of 4 (f32 size) before
+/// reinterpreting; previously `bytemuck::cast_slice` would panic on misalign.
 fn composite_row_over(
     bg: &[u8],
     fg: &[u8],
@@ -174,19 +189,40 @@ fn composite_row_over(
     fg_x_offset: usize,
     bg_width: usize,
     mode: zenblend::BlendMode,
-) {
+) -> crate::PipeResult<()> {
+    if bg.len() % 4 != 0 || fg.len() % 4 != 0 || out.len() % 4 != 0 {
+        return Err(at!(PipeError::DimensionMismatch(alloc::format!(
+            "composite row not f32-aligned: bg={} fg={} out={}",
+            bg.len(),
+            fg.len(),
+            out.len()
+        ))));
+    }
     let bg_f32: &[f32] = bytemuck::cast_slice(bg);
     let fg_f32: &[f32] = bytemuck::cast_slice(fg);
     let out_f32: &mut [f32] = bytemuck::cast_slice_mut(out);
 
-    // Start with background
-    out_f32.copy_from_slice(bg_f32);
+    // Make sure out can hold bg.
+    if out_f32.len() < bg_f32.len() {
+        return Err(at!(PipeError::DimensionMismatch(alloc::format!(
+            "composite out shorter than bg: out_f32={} bg_f32={}",
+            out_f32.len(),
+            bg_f32.len()
+        ))));
+    }
+    let bg_len = bg_f32.len();
+    out_f32[..bg_len].copy_from_slice(bg_f32);
 
-    // Determine the overlapping pixel range
+    // Determine the overlapping pixel range — checked add (audit H5d).
     let fg_pixels = fg_f32.len() / 4;
-    let blend_end = (fg_x_offset + fg_pixels).min(bg_width);
+    let fg_far = fg_x_offset.checked_add(fg_pixels).ok_or_else(|| {
+        at!(PipeError::LimitExceeded(alloc::format!(
+            "composite fg_x_offset+fg_pixels overflow: {fg_x_offset} + {fg_pixels}"
+        )))
+    })?;
+    let blend_end = fg_far.min(bg_width);
     if fg_x_offset >= blend_end {
-        return;
+        return Ok(());
     }
     let blend_pixels = blend_end - fg_x_offset;
 
@@ -208,4 +244,5 @@ fn composite_row_over(
     let bg_portion: alloc::vec::Vec<f32> = out_f32[dst_start..dst_end].to_vec();
     out_f32[dst_start..dst_end].copy_from_slice(&fg_f32[..fg_end]);
     zenblend::blend_row(&mut out_f32[dst_start..dst_end], &bg_portion, mode);
+    Ok(())
 }

--- a/src/sources/crop.rs
+++ b/src/sources/crop.rs
@@ -6,6 +6,7 @@ use whereat::at;
 
 use crate::error::PipeError;
 use crate::format::PixelFormat;
+use crate::limits::checked_dim_add;
 use crate::strip::{Strip, StripBuf};
 
 /// Crops a region from an upstream source without materializing.
@@ -39,13 +40,25 @@ impl CropSource {
         let uw = upstream.width();
         let uh = upstream.height();
 
-        if x + w > uw || y + h > uh {
+        // Reject wrap-around: x+w must fit in u32 and stay within source.
+        let x_end = checked_dim_add(x, w).map_err(|_| {
+            at!(PipeError::DimensionMismatch(alloc::format!(
+                "crop x+w overflow: x={x} w={w}"
+            )))
+        })?;
+        let y_end = checked_dim_add(y, h).map_err(|_| {
+            at!(PipeError::DimensionMismatch(alloc::format!(
+                "crop y+h overflow: y={y} h={h}"
+            )))
+        })?;
+        if x_end > uw || y_end > uh {
             return Err(at!(PipeError::DimensionMismatch(alloc::format!(
                 "crop ({x},{y},{w},{h}) exceeds source ({uw},{uh})"
             ))));
         }
 
         let sh = 16u32.min(h);
+        let buf = StripBuf::try_new(w, sh, fmt)?;
         Ok(Self {
             upstream,
             x,
@@ -54,7 +67,7 @@ impl CropSource {
             crop_h: h,
             format: fmt,
             strip_height: sh,
-            buf: StripBuf::new(w, sh, fmt),
+            buf,
             out_y: 0,
             upstream_y: 0,
         })
@@ -84,15 +97,17 @@ impl Source for CropSource {
             let strip = self.upstream.next()?;
             let Some(strip) = strip else { break };
 
+            // Pre-compute end-of-region; constructor verified y+crop_h fits.
+            let region_end = self.y.saturating_add(self.crop_h);
             for r in 0..strip.rows() {
-                let abs_y = self.upstream_y + r;
+                let abs_y = self.upstream_y.saturating_add(r);
 
                 // Skip rows before crop region
                 if abs_y < self.y {
                     continue;
                 }
                 // Stop after crop region
-                if abs_y >= self.y + self.crop_h {
+                if abs_y >= region_end {
                     self.out_y += self.buf.rows_filled();
                     return if self.buf.rows_filled() > 0 {
                         Ok(Some(self.buf.as_strip()))
@@ -109,7 +124,7 @@ impl Source for CropSource {
                 let cropped = Self::extract_row_into(src_row, self.x, self.crop_w, bpp);
                 self.buf.push_row(cropped);
             }
-            self.upstream_y += strip.rows();
+            self.upstream_y = self.upstream_y.saturating_add(strip.rows());
         }
 
         if self.buf.rows_filled() == 0 {

--- a/src/sources/edge_replicate.rs
+++ b/src/sources/edge_replicate.rs
@@ -10,7 +10,9 @@ use crate::Source;
 #[allow(unused_imports)]
 use whereat::at;
 
+use crate::error::PipeError;
 use crate::format::PixelFormat;
+use crate::limits::checked_buffer_size;
 use crate::strip::{Strip, StripBuf};
 
 /// Expands upstream content to canvas dimensions via edge replication.
@@ -67,11 +69,17 @@ impl EdgeReplicateSource {
         content_h: u32,
         canvas_w: u32,
         canvas_h: u32,
-    ) -> Self {
+    ) -> crate::PipeResult<Self> {
+        if canvas_w < content_w || canvas_h < content_h {
+            return Err(at!(PipeError::DimensionMismatch(alloc::format!(
+                "EdgeReplicate canvas ({canvas_w}x{canvas_h}) smaller than content ({content_w}x{content_h})"
+            ))));
+        }
         let format = upstream.format();
         let bpp = format.bytes_per_pixel();
-        let row_bytes = canvas_w as usize * bpp;
-        Self {
+        let row_bytes = checked_buffer_size(canvas_w, 1, bpp)?;
+        let buf = StripBuf::try_new(canvas_w, 16.min(canvas_h), format)?;
+        Ok(Self {
             upstream,
             content_w,
             content_h,
@@ -80,11 +88,11 @@ impl EdgeReplicateSource {
             format,
             bpp,
             last_row: vec![0u8; row_bytes],
-            buf: StripBuf::new(canvas_w, 16.min(canvas_h), format),
+            buf,
             y: 0,
             pending: None,
             upstream_done: false,
-        }
+        })
     }
 
     /// Pull next row from upstream (content area only).

--- a/src/sources/effects.rs
+++ b/src/sources/effects.rs
@@ -49,9 +49,9 @@ impl EffectSource {
         let height = upstream.height();
         let fmt = upstream.format();
         if fmt != format::RGBA8_SRGB {
-            return Err(at!(crate::error::PipeError::Op(alloc::string::String::from(
-                "EffectSource requires RGBA8_SRGB input"
-            ))));
+            return Err(at!(crate::error::PipeError::Op(
+                alloc::string::String::from("EffectSource requires RGBA8_SRGB input")
+            )));
         }
         limits.check(width, height, fmt)?;
 
@@ -98,7 +98,10 @@ impl EffectSource {
             if in_w != cur_w || in_h != cur_h {
                 return Err(at!(crate::error::PipeError::Op(alloc::format!(
                     "EffectSource: effect input_dims ({}x{}) don't match current buffer ({}x{})",
-                    in_w, in_h, cur_w, cur_h
+                    in_w,
+                    in_h,
+                    cur_w,
+                    cur_h
                 ))));
             }
 
@@ -118,10 +121,12 @@ impl EffectSource {
                 for ox in 0..out_w {
                     // `inverse_point` returns source coordinate for this output pixel.
                     // Centre-of-pixel convention: the center of pixel (ox, oy) is (ox + 0.5, oy + 0.5).
-                    let (sx, sy) = match effect
-                        .effect
-                        .inverse_point(ox as f32 + 0.5, oy as f32 + 0.5, in_w, in_h)
-                    {
+                    let (sx, sy) = match effect.effect.inverse_point(
+                        ox as f32 + 0.5,
+                        oy as f32 + 0.5,
+                        in_w,
+                        in_h,
+                    ) {
                         Some(p) => p,
                         None => {
                             // Content-adaptive effect — skip for now (fill with transparent).
@@ -164,7 +169,14 @@ impl Source for EffectSource {
         let end = (self.y + rows) as usize * stride;
         self.y += rows;
         Ok(Some(
-            Strip::new(&self.data[start..end], self.width, rows, stride, self.format).pipe_err()?,
+            Strip::new(
+                &self.data[start..end],
+                self.width,
+                rows,
+                stride,
+                self.format,
+            )
+            .pipe_err()?,
         ))
     }
 
@@ -227,7 +239,8 @@ fn sample_bilinear_rgba8(
     let w11 = fx * fy;
 
     for c in 0..4 {
-        let v = p00[c] as f32 * w00 + p10[c] as f32 * w10 + p01[c] as f32 * w01 + p11[c] as f32 * w11;
+        let v =
+            p00[c] as f32 * w00 + p10[c] as f32 * w10 + p01[c] as f32 * w01 + p11[c] as f32 * w11;
         dst[c] = v.round().clamp(0.0, 255.0) as u8;
     }
 }
@@ -236,8 +249,8 @@ fn sample_bilinear_rgba8(
 mod tests {
     use super::*;
     use crate::sources::MaterializedSource;
-    use zenlayout::dimension::{RotateEffect, RotateMode};
     use zenlayout::Size;
+    use zenlayout::dimension::{RotateEffect, RotateMode};
 
     fn solid_red_source(w: u32, h: u32) -> Box<dyn Source> {
         let mut data = vec![0u8; (w * h * 4) as usize];

--- a/src/sources/effects.rs
+++ b/src/sources/effects.rs
@@ -56,15 +56,33 @@ impl EffectSource {
         limits.check(width, height, fmt)?;
 
         let row_bytes = fmt.aligned_stride(width);
-        let mut data = vec![0u8; row_bytes * height as usize];
+        let total = crate::limits::checked_stride_buffer(row_bytes, height)?;
+        let mut data = vec![0u8; total];
         let mut y = 0u32;
         while let Some(strip) = upstream.next()? {
             for r in 0..strip.rows() {
-                let dst_start = (y + r) as usize * row_bytes;
+                let dst_start = (y as usize)
+                    .checked_add(r as usize)
+                    .and_then(|v| v.checked_mul(row_bytes))
+                    .ok_or_else(|| {
+                        at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                            "Effect dst offset overflow: y={y} r={r} row_bytes={row_bytes}"
+                        )))
+                    })?;
                 let src_row = strip.row(r);
-                data[dst_start..dst_start + row_bytes].copy_from_slice(&src_row[..row_bytes]);
+                let dst_end = dst_start.checked_add(row_bytes).ok_or_else(|| {
+                    at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                        "Effect dst end overflow"
+                    )))
+                })?;
+                if dst_end > data.len() {
+                    return Err(at!(crate::error::PipeError::DimensionMismatch(
+                        alloc::format!("Effect upstream over-produced rows")
+                    )));
+                }
+                data[dst_start..dst_end].copy_from_slice(&src_row[..row_bytes]);
             }
-            y += strip.rows();
+            y = y.saturating_add(strip.rows());
         }
 
         let mut cur_w = width;
@@ -84,10 +102,17 @@ impl EffectSource {
                 ))));
             }
 
+            // Re-check limits against the effect's *output* dims — declared
+            // output_dims can be larger than input (e.g., RotateEffect::Expand).
+            // Without this re-check, a chain of expanding effects would
+            // bypass the perimeter limit (audit M3 / C3 partial mitigation).
+            limits.check(out_w, out_h, fmt)?;
+
             // Inverse-mapping: for every output pixel, find source coordinate and interpolate.
-            let out_stride = (out_w as usize) * 4;
-            let mut out = vec![0u8; out_stride * out_h as usize];
-            let src_stride = (cur_w as usize) * 4;
+            let out_stride = crate::limits::checked_buffer_size(out_w, 1, 4)?;
+            let buf_size = crate::limits::checked_stride_buffer(out_stride, out_h)?;
+            let mut out = vec![0u8; buf_size];
+            let src_stride = crate::limits::checked_buffer_size(cur_w, 1, 4)?;
 
             for oy in 0..out_h {
                 for ox in 0..out_w {

--- a/src/sources/expand_canvas.rs
+++ b/src/sources/expand_canvas.rs
@@ -6,7 +6,9 @@ use crate::Source;
 #[allow(unused_imports)]
 use whereat::at;
 
+use crate::error::PipeError;
 use crate::format::PixelFormat;
+use crate::limits::checked_buffer_size;
 use crate::strip::{Strip, StripBuf};
 
 /// Streaming canvas expansion — places upstream on a larger canvas with padding.
@@ -61,6 +63,11 @@ impl ExpandCanvasSource {
     /// Place upstream content on a `canvas_w × canvas_h` canvas at offset
     /// `(place_x, place_y)`. Negative offsets crop the content; positive
     /// offsets add padding filled with `bg_pixel`.
+    ///
+    /// Returns `Err(LimitExceeded)` if `canvas_w * bpp` overflows `usize`.
+    /// `place_x`/`place_y` of [`i32::MIN`] are accepted via
+    /// [`unsigned_abs`](i32::unsigned_abs) (the previous `(-place_x) as u32`
+    /// would have wrapped).
     pub fn new(
         upstream: Box<dyn Source>,
         canvas_w: u32,
@@ -68,13 +75,14 @@ impl ExpandCanvasSource {
         place_x: i32,
         place_y: i32,
         bg_pixel: [u8; 4],
-    ) -> Self {
+    ) -> crate::PipeResult<Self> {
         let fmt = upstream.format();
         let src_w = upstream.width();
         let src_h = upstream.height();
 
-        let skip_x = if place_x < 0 { (-place_x) as u32 } else { 0 };
-        let skip_y = if place_y < 0 { (-place_y) as u32 } else { 0 };
+        // unsigned_abs handles i32::MIN correctly; -i32::MIN as u32 overflows.
+        let skip_x = if place_x < 0 { place_x.unsigned_abs() } else { 0 };
+        let skip_y = if place_y < 0 { place_y.unsigned_abs() } else { 0 };
         let dst_x = if place_x >= 0 { place_x as u32 } else { 0 };
         let dst_y = if place_y >= 0 { place_y as u32 } else { 0 };
 
@@ -85,16 +93,44 @@ impl ExpandCanvasSource {
             .saturating_sub(skip_y)
             .min(canvas_h.saturating_sub(dst_y));
 
-        // Pre-build a full background row
+        // Pre-build a full background row.
+        // Branch on bpp: chunks_exact_mut(4) is only correct for 4-byte
+        // pixels. For other bpp, replicate the appropriate prefix of the
+        // 4-byte bg_pixel (or zero-fill for non-RGBA layouts).
         let bpp = fmt.bytes_per_pixel();
-        let row_len = canvas_w as usize * bpp;
+        let row_len = checked_buffer_size(canvas_w, 1, bpp).map_err(|e| {
+            at!(PipeError::LimitExceeded(alloc::format!(
+                "ExpandCanvas bg_row size overflow: canvas_w={canvas_w} bpp={bpp}: {e}",
+                e = e.error()
+            )))
+        })?;
         let mut bg_row = vec![0u8; row_len];
-        for chunk in bg_row.chunks_exact_mut(4) {
-            chunk.copy_from_slice(&bg_pixel);
+        match bpp {
+            4 => {
+                for chunk in bg_row.chunks_exact_mut(4) {
+                    chunk.copy_from_slice(&bg_pixel);
+                }
+            }
+            3 => {
+                for chunk in bg_row.chunks_exact_mut(3) {
+                    chunk.copy_from_slice(&bg_pixel[..3]);
+                }
+            }
+            2 => {
+                for chunk in bg_row.chunks_exact_mut(2) {
+                    chunk.copy_from_slice(&bg_pixel[..2]);
+                }
+            }
+            1 => bg_row.fill(bg_pixel[0]),
+            // Wider pixels (U16/F32 multi-channel) — leave as zero rather
+            // than reinterpret a u8 4-tuple. Caller should not depend on a
+            // specific non-zero background for these formats.
+            _ => {}
         }
 
         let sh = 16u32.min(canvas_h);
-        Self {
+        let buf = StripBuf::try_new(canvas_w, sh, fmt)?;
+        Ok(Self {
             upstream,
             canvas_w,
             canvas_h,
@@ -107,12 +143,12 @@ impl ExpandCanvasSource {
             bg_row,
             format: fmt,
             strip_height: sh,
-            buf: StripBuf::new(canvas_w, sh, fmt),
+            buf,
             out_y: 0,
             pending: None,
             upstream_rows_consumed: 0,
             upstream_exhausted: false,
-        }
+        })
     }
 
     /// Pull the next upstream row, refilling the pending strip if needed.
@@ -185,11 +221,14 @@ impl Source for ExpandCanvasSource {
         self.buf.reset();
 
         let content_y_start = self.place_y;
-        let content_y_end = self.place_y + self.content_h;
+        // place_y + content_h validated bounded by canvas_h via construction
+        // (content_h = saturating_sub of canvas_h - place_y), so saturating_add
+        // here is safe and never produces an out-of-canvas value.
+        let content_y_end = self.place_y.saturating_add(self.content_h);
         let bpp = self.format.bytes_per_pixel();
 
         for r in 0..rows_wanted {
-            let canvas_y = self.out_y + r;
+            let canvas_y = self.out_y.saturating_add(r);
 
             if canvas_y >= content_y_start && canvas_y < content_y_end {
                 // Content row: start with bg, blit content pixels

--- a/src/sources/expand_canvas.rs
+++ b/src/sources/expand_canvas.rs
@@ -81,8 +81,16 @@ impl ExpandCanvasSource {
         let src_h = upstream.height();
 
         // unsigned_abs handles i32::MIN correctly; -i32::MIN as u32 overflows.
-        let skip_x = if place_x < 0 { place_x.unsigned_abs() } else { 0 };
-        let skip_y = if place_y < 0 { place_y.unsigned_abs() } else { 0 };
+        let skip_x = if place_x < 0 {
+            place_x.unsigned_abs()
+        } else {
+            0
+        };
+        let skip_y = if place_y < 0 {
+            place_y.unsigned_abs()
+        } else {
+            0
+        };
         let dst_x = if place_x >= 0 { place_x as u32 } else { 0 };
         let dst_y = if place_y >= 0 { place_y as u32 } else { 0 };
 

--- a/src/sources/icc_transform.rs
+++ b/src/sources/icc_transform.rs
@@ -135,20 +135,16 @@ impl Source for IccTransformSource {
         let row_bytes = dst_stride.min(src_stride);
         let src_bytes = strip.as_strided_bytes();
         for r in 0..height {
-            let src_start = (r as usize)
-                .checked_mul(src_stride)
-                .ok_or_else(|| {
-                    at!(PipeError::LimitExceeded(alloc::format!(
-                        "icc src offset overflow: r={r} src_stride={src_stride}"
-                    )))
-                })?;
-            let dst_start = (r as usize)
-                .checked_mul(dst_stride)
-                .ok_or_else(|| {
-                    at!(PipeError::LimitExceeded(alloc::format!(
-                        "icc dst offset overflow: r={r} dst_stride={dst_stride}"
-                    )))
-                })?;
+            let src_start = (r as usize).checked_mul(src_stride).ok_or_else(|| {
+                at!(PipeError::LimitExceeded(alloc::format!(
+                    "icc src offset overflow: r={r} src_stride={src_stride}"
+                )))
+            })?;
+            let dst_start = (r as usize).checked_mul(dst_stride).ok_or_else(|| {
+                at!(PipeError::LimitExceeded(alloc::format!(
+                    "icc dst offset overflow: r={r} dst_stride={dst_stride}"
+                )))
+            })?;
             // Defensive bound check — upstream may lie about row length.
             let src_end = src_start
                 .checked_add(row_bytes)

--- a/src/sources/icc_transform.rs
+++ b/src/sources/icc_transform.rs
@@ -121,23 +121,53 @@ impl Source for IccTransformSource {
 
         let width = strip.width();
         let height = strip.rows();
-        let stride = self.format.aligned_stride(width);
-        let total_bytes = stride * height as usize;
+        let dst_stride = self.format.aligned_stride(width);
+        let src_stride = strip.stride();
+        let total_bytes = crate::limits::checked_stride_buffer(dst_stride, height)?;
 
         self.buf.resize(total_bytes, 0);
 
+        // Use the ROW length the CMS expects (dst_stride covers `width`
+        // pixels at the destination format) for the slice it transforms,
+        // but slice the source by ITS stride. Mixing the two — as the
+        // pre-fix code did — caused either OOB reads (if src_stride <
+        // dst_stride) or silent truncation (if src_stride > dst_stride).
+        let row_bytes = dst_stride.min(src_stride);
+        let src_bytes = strip.as_strided_bytes();
         for r in 0..height {
-            let src_start = r as usize * strip.stride();
-            let dst_start = r as usize * stride;
+            let src_start = (r as usize)
+                .checked_mul(src_stride)
+                .ok_or_else(|| {
+                    at!(PipeError::LimitExceeded(alloc::format!(
+                        "icc src offset overflow: r={r} src_stride={src_stride}"
+                    )))
+                })?;
+            let dst_start = (r as usize)
+                .checked_mul(dst_stride)
+                .ok_or_else(|| {
+                    at!(PipeError::LimitExceeded(alloc::format!(
+                        "icc dst offset overflow: r={r} dst_stride={dst_stride}"
+                    )))
+                })?;
+            // Defensive bound check — upstream may lie about row length.
+            let src_end = src_start
+                .checked_add(row_bytes)
+                .filter(|&end| end <= src_bytes.len())
+                .ok_or_else(|| {
+                    at!(PipeError::DimensionMismatch(alloc::format!(
+                        "icc upstream row {r} out of bounds: need {row_bytes} bytes from offset {src_start} of {len}",
+                        len = src_bytes.len()
+                    )))
+                })?;
             self.transform.transform_row(
-                &strip.as_strided_bytes()[src_start..src_start + stride],
-                &mut self.buf[dst_start..dst_start + stride],
+                &src_bytes[src_start..src_end],
+                &mut self.buf[dst_start..dst_start + row_bytes],
                 width,
             );
         }
 
         Ok(Some(
-            Strip::new(&self.buf, width, height, stride, self.format).pipe_err()?,
+            Strip::new(&self.buf, width, height, dst_stride, self.format).pipe_err()?,
         ))
     }
 

--- a/src/sources/materialize.rs
+++ b/src/sources/materialize.rs
@@ -46,6 +46,8 @@ impl MaterializedSource {
     /// Drain all strips from `upstream` into memory, checking `stop` between strips.
     ///
     /// Returns `PipeError::Cancelled` if the stop signal fires mid-drain.
+    /// Returns `PipeError::LimitExceeded` if `stride * height` overflows
+    /// `usize` (audit C2).
     pub fn from_source_stoppable(
         mut upstream: Box<dyn Source>,
         stop: &dyn enough::Stop,
@@ -54,18 +56,39 @@ impl MaterializedSource {
         let height = upstream.height();
         let format = upstream.format();
         let row_bytes = format.aligned_stride(width);
-        let mut data = vec![0u8; row_bytes * height as usize];
+        let total = crate::limits::checked_stride_buffer(row_bytes, height)?;
+        let mut data = vec![0u8; total];
         let mut y = 0u32;
 
         while let Some(strip) = upstream.next()? {
             stop.check()
                 .map_err(|_| at!(crate::error::PipeError::Cancelled))?;
             for r in 0..strip.rows() {
-                let dst_start = (y + r) as usize * row_bytes;
+                let dst_start = (y as usize)
+                    .checked_add(r as usize)
+                    .and_then(|v| v.checked_mul(row_bytes))
+                    .ok_or_else(|| {
+                        at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                            "Materialize dst offset overflow: y={y} r={r} row_bytes={row_bytes}"
+                        )))
+                    })?;
                 let src_row = strip.row(r);
-                data[dst_start..dst_start + row_bytes].copy_from_slice(&src_row[..row_bytes]);
+                let dst_end = dst_start.checked_add(row_bytes).ok_or_else(|| {
+                    at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                        "Materialize dst end overflow: dst_start={dst_start} row_bytes={row_bytes}"
+                    )))
+                })?;
+                if dst_end > data.len() {
+                    return Err(at!(crate::error::PipeError::DimensionMismatch(
+                        alloc::format!(
+                            "Materialize upstream over-produced rows: dst_end={dst_end} buf={}",
+                            data.len()
+                        )
+                    )));
+                }
+                data[dst_start..dst_end].copy_from_slice(&src_row[..row_bytes]);
             }
-            y += strip.rows();
+            y = y.saturating_add(strip.rows());
         }
 
         Ok(Self {

--- a/src/sources/tee.rs
+++ b/src/sources/tee.rs
@@ -58,22 +58,53 @@ impl TeeSource {
     }
 
     /// Materialize the upstream source and prepare for fan-out.
+    ///
+    /// Returns `LimitExceeded` if `width * bpp * height` overflows `usize`
+    /// or if upstream produces more rows than the declared height (audit C2).
     pub fn new(mut upstream: Box<dyn Source>) -> crate::PipeResult<Self> {
         let width = upstream.width();
         let height = upstream.height();
         let format = upstream.format();
-        let stride = width as usize * format.bytes_per_pixel();
+        let bpp = format.bytes_per_pixel();
+        let stride = (width as usize).checked_mul(bpp).ok_or_else(|| {
+            at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                "Tee stride overflow: width={width} bpp={bpp}"
+            )))
+        })?;
+        let total = crate::limits::checked_stride_buffer(stride, height)?;
 
-        let mut data = vec![0u8; stride * height as usize];
+        let mut data = vec![0u8; total];
         let mut y = 0usize;
 
         while let Some(strip) = upstream.next()? {
             for r in 0..strip.rows() {
-                let dst_start = (y + r as usize) * stride;
+                let row_idx = y.checked_add(r as usize).ok_or_else(|| {
+                    at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                        "Tee row index overflow: y={y} r={r}"
+                    )))
+                })?;
+                let dst_start = row_idx.checked_mul(stride).ok_or_else(|| {
+                    at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                        "Tee dst offset overflow: row_idx={row_idx} stride={stride}"
+                    )))
+                })?;
+                let dst_end = dst_start.checked_add(stride).ok_or_else(|| {
+                    at!(crate::error::PipeError::LimitExceeded(alloc::format!(
+                        "Tee dst end overflow: dst_start={dst_start} stride={stride}"
+                    )))
+                })?;
+                if dst_end > data.len() {
+                    return Err(at!(crate::error::PipeError::DimensionMismatch(
+                        alloc::format!(
+                            "Tee upstream over-produced rows: dst_end={dst_end} buf={}",
+                            data.len()
+                        )
+                    )));
+                }
                 let src_row = strip.row(r);
-                data[dst_start..dst_start + stride].copy_from_slice(&src_row[..stride]);
+                data[dst_start..dst_end].copy_from_slice(&src_row[..stride]);
             }
-            y += strip.rows() as usize;
+            y = y.saturating_add(strip.rows() as usize);
         }
 
         Ok(Self {

--- a/src/sources/windowed_filter.rs
+++ b/src/sources/windowed_filter.rs
@@ -112,19 +112,54 @@ impl WindowedFilterSource {
 
         let width = upstream.width();
         let height = upstream.height();
-        let row_len = width as usize * 4; // RGBA f32
+        // RGBA f32 row — count of f32 elements per row (= width * 4 channels).
+        let row_len = (width as usize).checked_mul(4).ok_or_else(|| {
+            at!(PipeError::LimitExceeded(alloc::format!(
+                "WindowedFilter row_len overflow: width={width}"
+            )))
+        })?;
 
         // Scale strip height to target ~75% utilization:
         // utilization = strip / (strip + 2*overlap). For 75%: strip = 6*overlap.
         // Minimum 64, capped to image height. Large strips amortize overlap cost.
+        // `overlap` flows from `pipeline.max_neighborhood_radius` and is
+        // otherwise untrusted — checked_mul rejects overflow rather than
+        // wrapping to a tiny strip / window size.
         let strip_height = if overlap > 0 {
-            (overlap * 6).max(64).min(height)
+            let times_six = overlap.checked_mul(6).ok_or_else(|| {
+                at!(PipeError::LimitExceeded(alloc::format!(
+                    "WindowedFilter overlap*6 overflow: overlap={overlap}"
+                )))
+            })?;
+            times_six.max(64).min(height)
         } else {
             64.min(height)
         };
 
         // Max window = strip_height + 2*overlap, capped to image height
-        let max_window = (strip_height + 2 * overlap).min(height);
+        let two_overlap = overlap.checked_mul(2).ok_or_else(|| {
+            at!(PipeError::LimitExceeded(alloc::format!(
+                "WindowedFilter 2*overlap overflow: overlap={overlap}"
+            )))
+        })?;
+        let max_window = strip_height
+            .checked_add(two_overlap)
+            .ok_or_else(|| {
+                at!(PipeError::LimitExceeded(alloc::format!(
+                    "WindowedFilter strip+2*overlap overflow: strip={strip_height} 2*overlap={two_overlap}"
+                )))
+            })?
+            .min(height);
+
+        // Compute the f32-element count for the row buffers and reject
+        // overflow before reaching the infallible vec! allocations.
+        let total_f32 = row_len.checked_mul(max_window as usize).ok_or_else(|| {
+            at!(PipeError::LimitExceeded(alloc::format!(
+                "WindowedFilter buffer overflow: row_len={row_len} max_window={max_window}"
+            )))
+        })?;
+
+        let out_strip = StripBuf::try_new(width, strip_height, format::RGBAF32_LINEAR)?;
 
         Ok(Self {
             upstream,
@@ -134,12 +169,12 @@ impl WindowedFilterSource {
             strip_height,
             width,
             total_height: height,
-            row_buf: vec![0.0f32; row_len * max_window as usize],
+            row_buf: vec![0.0f32; total_f32],
             row_len,
             buf_start_y: 0,
             buf_rows: 0,
-            out_f32: vec![0.0f32; row_len * max_window as usize],
-            out_strip: StripBuf::new(width, strip_height, format::RGBAF32_LINEAR),
+            out_f32: vec![0.0f32; total_f32],
+            out_strip,
             output_y: 0,
             upstream_y: 0,
             upstream_done: false,
@@ -164,10 +199,9 @@ impl WindowedFilterSource {
         if let Some(ref mut pending) = self.pending {
             if pending.remaining() > 0 {
                 let row_u8 = pending.row(pending.next_row);
-                let row_f32: &[f32] = bytemuck::cast_slice(row_u8);
-                let result = row_f32[..self.row_len].to_vec();
+                let result = u8_row_to_f32_vec(row_u8, self.row_len)?;
                 pending.next_row += 1;
-                self.upstream_y += 1;
+                self.upstream_y = self.upstream_y.saturating_add(1);
                 if pending.remaining() == 0 {
                     self.pending = None;
                 }
@@ -194,10 +228,9 @@ impl WindowedFilterSource {
         };
 
         let row_u8 = pending.row(0);
-        let row_f32: &[f32] = bytemuck::cast_slice(row_u8);
-        let result = row_f32[..self.row_len].to_vec();
+        let result = u8_row_to_f32_vec(row_u8, self.row_len)?;
         pending.next_row = 1;
-        self.upstream_y += 1;
+        self.upstream_y = self.upstream_y.saturating_add(1);
 
         if pending.remaining() > 0 {
             self.pending = Some(pending);
@@ -211,9 +244,13 @@ impl WindowedFilterSource {
     fn prepare_window(&mut self) -> crate::PipeResult<(u32, u32)> {
         let y = self.output_y;
 
-        // Window bounds (global coordinates)
+        // Window bounds (global coordinates) — saturating arithmetic so a
+        // huge overlap can't push the additions past u32::MAX.
         let window_top = y.saturating_sub(self.overlap);
-        let window_bottom = (y + self.strip_height + self.overlap).min(self.total_height);
+        let window_bottom = y
+            .saturating_add(self.strip_height)
+            .saturating_add(self.overlap)
+            .min(self.total_height);
         let window_height = window_bottom - window_top;
         let output_offset = y - window_top; // offset of first output row in window
 
@@ -305,4 +342,24 @@ impl Source for WindowedFilterSource {
     fn format(&self) -> PixelFormat {
         format::RGBAF32_LINEAR
     }
+}
+
+/// Validate that a u8 row is `expected_f32 * 4` bytes and reinterpret as
+/// f32, returning a vec. Returns `DimensionMismatch` instead of letting
+/// `bytemuck::cast_slice` panic on a misaligned upstream row.
+fn u8_row_to_f32_vec(row_u8: &[u8], expected_f32: usize) -> crate::PipeResult<Vec<f32>> {
+    let needed_bytes = expected_f32.checked_mul(4).ok_or_else(|| {
+        at!(PipeError::LimitExceeded(alloc::format!(
+            "WindowedFilter row byte size overflow: {expected_f32} f32"
+        )))
+    })?;
+    if row_u8.len() < needed_bytes || row_u8.len() % 4 != 0 {
+        return Err(at!(PipeError::DimensionMismatch(alloc::format!(
+            "WindowedFilter upstream row not f32-aligned or short: have {} bytes, need {}",
+            row_u8.len(),
+            needed_bytes
+        ))));
+    }
+    let row_f32: &[f32] = bytemuck::cast_slice(&row_u8[..needed_bytes]);
+    Ok(row_f32.to_vec())
 }

--- a/src/strip.rs
+++ b/src/strip.rs
@@ -29,17 +29,34 @@ pub struct StripBuf {
 
 impl StripBuf {
     /// Create a new strip buffer with space for `max_rows` rows.
+    ///
+    /// Panics if `stride * max_rows` overflows `usize`. Use
+    /// [`try_new`](Self::try_new) for fallible construction; the panic
+    /// path remains for backwards compatibility with infallible callers,
+    /// but new code should prefer the fallible variant.
     pub fn new(width: u32, max_rows: u32, format: PixelFormat) -> Self {
+        Self::try_new(width, max_rows, format)
+            .unwrap_or_else(|e| panic!("StripBuf::new: dimension overflow: {}", e.error()))
+    }
+
+    /// Fallible constructor. Returns `Err(LimitExceeded)` if
+    /// `stride * max_rows` overflows `usize` (reachable on 32-bit / wasm32).
+    pub fn try_new(
+        width: u32,
+        max_rows: u32,
+        format: PixelFormat,
+    ) -> crate::PipeResult<Self> {
         let stride = format.aligned_stride(width);
-        Self {
-            data: vec![0u8; stride * max_rows as usize],
+        let total = crate::limits::checked_stride_buffer(stride, max_rows)?;
+        Ok(Self {
+            data: vec![0u8; total],
             width,
             stride,
             format,
             color: None,
             rows_filled: 0,
             capacity_rows: max_rows,
-        }
+        })
     }
 
     /// Set the color context for strips produced by this buffer.
@@ -126,19 +143,34 @@ impl StripBuf {
     }
 
     /// Resize buffer for a different format/width (reallocates if needed).
+    ///
+    /// Panics if `stride * max_rows` overflows `usize`. Prefer
+    /// [`try_reconfigure`](Self::try_reconfigure) on untrusted input.
     pub fn reconfigure(&mut self, width: u32, max_rows: u32, format: PixelFormat) {
+        self.try_reconfigure(width, max_rows, format)
+            .unwrap_or_else(|e| panic!("StripBuf::reconfigure: dimension overflow: {}", e.error()))
+    }
+
+    /// Fallible variant of [`reconfigure`](Self::reconfigure).
+    pub fn try_reconfigure(
+        &mut self,
+        width: u32,
+        max_rows: u32,
+        format: PixelFormat,
+    ) -> crate::PipeResult<()> {
         let stride = format.aligned_stride(width);
         if self.width != width || self.capacity_rows != max_rows || self.format != format {
+            let needed = crate::limits::checked_stride_buffer(stride, max_rows)?;
             self.width = width;
             self.stride = stride;
             self.format = format;
             self.capacity_rows = max_rows;
-            let needed = stride * max_rows as usize;
             if self.data.len() < needed {
                 self.data.resize(needed, 0);
             }
         }
         self.rows_filled = 0;
+        Ok(())
     }
 }
 

--- a/src/strip.rs
+++ b/src/strip.rs
@@ -41,11 +41,7 @@ impl StripBuf {
 
     /// Fallible constructor. Returns `Err(LimitExceeded)` if
     /// `stride * max_rows` overflows `usize` (reachable on 32-bit / wasm32).
-    pub fn try_new(
-        width: u32,
-        max_rows: u32,
-        format: PixelFormat,
-    ) -> crate::PipeResult<Self> {
+    pub fn try_new(width: u32, max_rows: u32, format: PixelFormat) -> crate::PipeResult<Self> {
         let stride = format.aligned_stride(width);
         let total = crate::limits::checked_stride_buffer(stride, max_rows)?;
         Ok(Self {

--- a/src/watermark.rs
+++ b/src/watermark.rs
@@ -171,16 +171,28 @@ fn compute_bounding_box(w: u32, h: u32, fit_box: &FitBox) -> Option<(i32, i32, i
             right,
             bottom,
         } => {
-            if left + right < w && top + bottom < h {
-                Some((
-                    *left as i32,
-                    *top as i32,
-                    w as i32 - *right as i32,
-                    h as i32 - *bottom as i32,
-                ))
-            } else {
-                None
+            // Reject u32 wrap on left+right / top+bottom (audit M9), and
+            // reject margin values that don't fit i32 since downstream
+            // arithmetic uses signed offsets.
+            let lr = left.checked_add(*right)?;
+            let tb = top.checked_add(*bottom)?;
+            if lr >= w || tb >= h {
+                return None;
             }
+            if *left > i32::MAX as u32
+                || *top > i32::MAX as u32
+                || *right > i32::MAX as u32
+                || *bottom > i32::MAX as u32
+                || w > i32::MAX as u32
+                || h > i32::MAX as u32
+            {
+                return None;
+            }
+            let x0 = *left as i32;
+            let y0 = *top as i32;
+            let x1 = (w as i32).checked_sub(*right as i32)?;
+            let y1 = (h as i32).checked_sub(*bottom as i32)?;
+            Some((x0, y0, x1, y1))
         }
         FitBox::Percentage { x1, y1, x2, y2 } => {
             let to_px = |pct: f32, dim: u32| -> i32 {

--- a/tests/coverage_fill.rs
+++ b/tests/coverage_fill.rs
@@ -104,7 +104,7 @@ fn expand_canvas_padding_all_sides() {
     // 4x4 red image placed at (2, 2) on an 8x8 canvas with blue background
     let src = solid_source(4, 4, [255, 0, 0, 255]);
     let bg = [0, 0, 255, 255]; // blue
-    let mut canvas = ExpandCanvasSource::new(src, 8, 8, 2, 2, bg);
+    let mut canvas = ExpandCanvasSource::new(src, 8, 8, 2, 2, bg).unwrap();
 
     assert_eq!(canvas.width(), 8);
     assert_eq!(canvas.height(), 8);
@@ -144,7 +144,7 @@ fn expand_canvas_padding_all_sides() {
 fn expand_canvas_no_padding() {
     // Place a 4x4 image at (0, 0) on a 4x4 canvas — should be identity
     let src = solid_source(4, 4, [42, 42, 42, 255]);
-    let mut canvas = ExpandCanvasSource::new(src, 4, 4, 0, 0, [0, 0, 0, 0]);
+    let mut canvas = ExpandCanvasSource::new(src, 4, 4, 0, 0, [0, 0, 0, 0]).unwrap();
 
     assert_eq!(canvas.width(), 4);
     assert_eq!(canvas.height(), 4);
@@ -161,7 +161,7 @@ fn expand_canvas_negative_offset_crops_content() {
     // Place at (-2, -1) on a 4x4 canvas: skip 2 source cols, 1 source row
     // Source is 6x6 gradient, canvas is 4x4
     let src = gradient_source(6, 6);
-    let mut canvas = ExpandCanvasSource::new(src, 4, 4, -2, -1, [0, 0, 0, 255]);
+    let mut canvas = ExpandCanvasSource::new(src, 4, 4, -2, -1, [0, 0, 0, 255]).unwrap();
 
     assert_eq!(canvas.width(), 4);
     assert_eq!(canvas.height(), 4);
@@ -183,7 +183,7 @@ fn expand_canvas_negative_offset_crops_content() {
 fn expand_canvas_larger_canvas_than_source() {
     // 2x2 source, 10x10 canvas, placed at (4, 4)
     let src = solid_source(2, 2, [128, 64, 32, 255]);
-    let mut canvas = ExpandCanvasSource::new(src, 10, 10, 4, 4, [0, 0, 0, 255]);
+    let mut canvas = ExpandCanvasSource::new(src, 10, 10, 4, 4, [0, 0, 0, 255]).unwrap();
 
     assert_eq!(canvas.width(), 10);
     assert_eq!(canvas.height(), 10);

--- a/tests/pipeline.rs
+++ b/tests/pipeline.rs
@@ -486,7 +486,7 @@ fn edge_replicate_right_and_bottom() {
     }
 
     let src = CallbackSource::from_data(&data, width, height, format::RGBA8_SRGB, 16);
-    let mut edge = EdgeReplicateSource::new(Box::new(src), 4, 3, 6, 5);
+    let mut edge = EdgeReplicateSource::new(Box::new(src), 4, 3, 6, 5).unwrap();
 
     assert_eq!(edge.width(), 6);
     assert_eq!(edge.height(), 5);
@@ -518,7 +518,7 @@ fn edge_replicate_right_and_bottom() {
 fn edge_replicate_no_expansion() {
     // When content == canvas, should pass through unchanged
     let src = solid_rgba8(4, 4, 100, 200, 50, 255);
-    let mut edge = EdgeReplicateSource::new(Box::new(src), 4, 4, 4, 4);
+    let mut edge = EdgeReplicateSource::new(Box::new(src), 4, 4, 4, 4).unwrap();
 
     assert_eq!(edge.width(), 4);
     assert_eq!(edge.height(), 4);

--- a/tests/riapi_keys.rs
+++ b/tests/riapi_keys.rs
@@ -1079,7 +1079,8 @@ fn paddingcolor_sets_color() {
     let r = expand_zen("w=800&h=600&margin=5&paddingcolor=white");
     let ec = find_expanded_node(&r.nodes, "zenlayout.expand_canvas").expect("ExpandCanvas node");
     assert_eq!(
-        ec.get_param("color").and_then(|v| v.as_str().map(String::from)),
+        ec.get_param("color")
+            .and_then(|v| v.as_str().map(String::from)),
         Some("white".to_string())
     );
 }
@@ -1093,7 +1094,8 @@ fn borderwidth_applies_to_all_sides() {
         assert_eq!(ec.get_param(side).and_then(|v| v.as_u32()), Some(3));
     }
     assert_eq!(
-        ec.get_param("color").and_then(|v| v.as_str().map(String::from)),
+        ec.get_param("color")
+            .and_then(|v| v.as_str().map(String::from)),
         Some("red".to_string())
     );
 }

--- a/tests/security_audit.rs
+++ b/tests/security_audit.rs
@@ -1,0 +1,181 @@
+//! Regression tests for the 2026-05-06 security audit.
+//!
+//! Each test corresponds to a CRITICAL or HIGH finding. Failures here mean
+//! a previously-fixed defense was reintroduced.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread;
+
+use zenpipe::graph::{EdgeKind, NodeOp, PipelineGraph};
+use zenpipe::limits::{
+    AllocationTracker, checked_buffer_size, checked_dim_add, checked_stride_buffer,
+};
+use zenpipe::sources::{CropSource, ExpandCanvasSource, MaterializedSource};
+use zenpipe::{PipeError, format};
+
+// -----------------------------------------------------------------------
+// C1: dfs_cycle_check must not blow the stack on a deep linear DAG.
+// -----------------------------------------------------------------------
+
+#[test]
+fn audit_c1_deep_linear_dag_does_not_stack_overflow() {
+    // A linear chain of N RowConverter nodes used to recurse N levels deep.
+    // 50_000 frames is comfortably above the typical OS stack budget but
+    // still terminates quickly via the iterative cycle-check.
+    const N: usize = 50_000;
+    let mut g = PipelineGraph::new();
+
+    // Source node first.
+    let src = g.add_node(NodeOp::Source);
+    let mut prev = src;
+    for _ in 0..N {
+        // Use FillRect as a pass-through node; any non-Source node works.
+        let id = g.add_node(NodeOp::FillRect {
+            x1: 0,
+            y1: 0,
+            x2: 1,
+            y2: 1,
+            color: [0, 0, 0, 0],
+        });
+        g.add_edge(prev, id, EdgeKind::Input);
+        prev = id;
+    }
+    let out = g.add_node(NodeOp::Output);
+    g.add_edge(prev, out, EdgeKind::Input);
+
+    // validate() runs the cycle check. Should error out via MAX_GRAPH_DEPTH
+    // or succeed cleanly; either way it must NOT abort the process.
+    let res = g.validate();
+    // The graph is acyclic, so a too-deep complaint is acceptable; what
+    // matters is that we returned at all instead of stack-overflowing.
+    let _ = res;
+}
+
+// -----------------------------------------------------------------------
+// C2: checked_buffer_size / checked_stride_buffer reject overflow.
+// -----------------------------------------------------------------------
+
+#[test]
+fn audit_c2_checked_buffer_size_rejects_overflow() {
+    // On 64-bit the wrap is harder to hit, but 2^63 * 4 saturates usize on
+    // both 32-bit and 64-bit.
+    let huge = u32::MAX;
+    let res = checked_buffer_size(huge, huge, 4);
+    assert!(matches!(
+        res.as_ref().map_err(|e| e.error()),
+        Err(PipeError::LimitExceeded(_))
+    ));
+}
+
+#[test]
+fn audit_c2_checked_stride_buffer_rejects_overflow() {
+    let res = checked_stride_buffer(usize::MAX / 2, u32::MAX);
+    assert!(matches!(
+        res.as_ref().map_err(|e| e.error()),
+        Err(PipeError::LimitExceeded(_))
+    ));
+}
+
+#[test]
+fn audit_c2_checked_dim_add_rejects_wrap() {
+    assert!(checked_dim_add(u32::MAX, 1).is_err());
+    assert_eq!(checked_dim_add(100, 200).unwrap(), 300);
+}
+
+// -----------------------------------------------------------------------
+// H1: AllocationTracker must enforce limit under concurrency.
+// -----------------------------------------------------------------------
+
+#[test]
+fn audit_h1_allocation_tracker_enforces_limit_concurrently() {
+    let limit_bytes = 1024 * 1024; // 1 MB
+    let tracker = Arc::new(AllocationTracker::new(limit_bytes));
+
+    // Each thread tries to grab `limit_bytes / 2 + 1` bytes. With a TOCTOU
+    // race-prone implementation, both could pass the check and exceed the
+    // limit by ~limit_bytes/2. With the compare_exchange loop, at most one
+    // wins and the other surfaces a LimitExceeded error.
+    let total_grabbed = Arc::new(AtomicU64::new(0));
+    let mut handles = vec![];
+    for _ in 0..16 {
+        let t = Arc::clone(&tracker);
+        let g = Arc::clone(&total_grabbed);
+        handles.push(thread::spawn(move || {
+            for _ in 0..50 {
+                if let Ok(_guard) = t.allocate(limit_bytes / 2 + 1) {
+                    g.fetch_add(limit_bytes / 2 + 1, Ordering::SeqCst);
+                    // hold briefly
+                    std::thread::yield_now();
+                }
+            }
+        }));
+    }
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    // The tracker may briefly hit but must never EXCEED the limit at any
+    // point. Peak should be <= limit_bytes.
+    assert!(
+        tracker.peak_bytes() <= limit_bytes,
+        "peak {} exceeds limit {}",
+        tracker.peak_bytes(),
+        limit_bytes
+    );
+}
+
+#[test]
+fn audit_h1_allocation_tracker_rejects_u64_overflow() {
+    let tracker = Arc::new(AllocationTracker::new(1024));
+    // Ask for u64::MAX. checked_add(current, u64::MAX) overflows -> error.
+    assert!(tracker.allocate(u64::MAX).is_err());
+}
+
+// -----------------------------------------------------------------------
+// H2: CropSource must reject u32 wrap on x+w / y+h.
+// -----------------------------------------------------------------------
+
+#[test]
+fn audit_h2_crop_rejects_x_plus_w_wrap() {
+    let src = MaterializedSource::from_data(vec![0u8; 4 * 4], 4, 4, format::RGBA8_SRGB);
+    let res = CropSource::new(Box::new(src), u32::MAX, 0, 1, 1);
+    assert!(matches!(
+        res.as_ref().map_err(|e| e.error()),
+        Err(PipeError::DimensionMismatch(_))
+    ));
+}
+
+#[test]
+fn audit_h2_crop_rejects_y_plus_h_wrap() {
+    let src = MaterializedSource::from_data(vec![0u8; 4 * 4], 4, 4, format::RGBA8_SRGB);
+    let res = CropSource::new(Box::new(src), 0, u32::MAX, 1, 1);
+    assert!(matches!(
+        res.as_ref().map_err(|e| e.error()),
+        Err(PipeError::DimensionMismatch(_))
+    ));
+}
+
+// -----------------------------------------------------------------------
+// H3: ExpandCanvas i32::MIN place_x must use unsigned_abs, not negation.
+// -----------------------------------------------------------------------
+
+#[test]
+fn audit_h3_expand_canvas_accepts_i32_min_place() {
+    // Construction with place_x = i32::MIN previously wrapped through
+    // `(-place_x) as u32` and produced skip_x = 0x8000_0000.
+    // Now uses unsigned_abs and should produce skip_x = 2^31 cleanly.
+    let src = MaterializedSource::from_data(vec![0u8; 4 * 4], 4, 4, format::RGBA8_SRGB);
+    let res = ExpandCanvasSource::new(Box::new(src), 8, 8, i32::MIN, 0, [0, 0, 0, 0]);
+    // Construction succeeds (saturating_sub gives content_w = 0). The key
+    // is that we don't panic from the negation.
+    assert!(res.is_ok());
+}
+
+// -----------------------------------------------------------------------
+// H7: ExpandCanvas canvas dims with u32 wrap are rejected at compile.
+// -----------------------------------------------------------------------
+
+// Covered indirectly by audit_c2_checked_dim_add_rejects_wrap and the
+// graph compile path that wraps the addition in checked_add — exercised
+// via the existing graph fuzz tests.

--- a/tests/wide_gamut_pipeline_gap.rs
+++ b/tests/wide_gamut_pipeline_gap.rs
@@ -95,11 +95,14 @@ fn gainmap_preserve_mode_round_trips_through_pipeline_unchanged() {
 fn jpeg_icc_preserve_round_trips_icc_bytes_verbatim() {
     use rgb::Rgb;
     let pixels: Vec<Rgb<u8>> = (0..32 * 32)
-        .map(|i| Rgb { r: (i % 32) as u8, g: (i / 32) as u8, b: 100 })
+        .map(|i| Rgb {
+            r: (i % 32) as u8,
+            g: (i / 32) as u8,
+            b: 100,
+        })
         .collect();
     let img = imgref::ImgVec::new(pixels, 32, 32);
-    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> =
-        zenpixels::PixelSlice::from(img.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> = zenpixels::PixelSlice::from(img.as_ref());
 
     // Synthetic non-sRGB ICC — what matters is that it is NOT detected as
     // sRGB so the Preserve path actually has to carry it. Using a pattern
@@ -187,7 +190,9 @@ fn avif_rec2020_pq_round_trips_primaries() {
     // Pending real AVIF Rec.2020 PQ generation. Today this test would
     // need a fixture file; once the pipeline preserves primaries, the
     // test should round-trip without needing one.
-    panic!("Test body pending fixture; assertion: decoded.cicp.primaries == 9 (Rec.2020) after ImageJob round-trip");
+    panic!(
+        "Test body pending fixture; assertion: decoded.cicp.primaries == 9 (Rec.2020) after ImageJob round-trip"
+    );
 }
 
 /// AVIF 10/12-bit decode already preserves bit depth at the codec layer

--- a/zencodecs/src/encode.rs
+++ b/zencodecs/src/encode.rs
@@ -543,9 +543,7 @@ impl<'a> EncodeRequest<'a> {
         img: imgref::ImgRef<'_, rgb::Bgra<u8>>,
     ) -> Result<EncodeOutput> {
         let typed: zenpixels::PixelSlice<'_, rgb::Bgra<u8>> = zenpixels::PixelSlice::from(img);
-        let pixels = typed
-            .with_descriptor(PixelDescriptor::BGRX8_SRGB)
-            .erase();
+        let pixels = typed.with_descriptor(PixelDescriptor::BGRX8_SRGB).erase();
         self.encode(pixels, false)
     }
 

--- a/zencodecs/tests/avif_capability.rs
+++ b/zencodecs/tests/avif_capability.rs
@@ -37,11 +37,7 @@ fn encode_avif_rgb8(img: ImgRef<'_, Rgb<u8>>, quality: f32) -> Vec<u8> {
 }
 
 #[cfg(feature = "avif-encode")]
-fn encode_avif_with_meta(
-    img: ImgRef<'_, Rgb<u8>>,
-    meta: Metadata,
-    quality: f32,
-) -> Vec<u8> {
+fn encode_avif_with_meta(img: ImgRef<'_, Rgb<u8>>, meta: Metadata, quality: f32) -> Vec<u8> {
     let typed: PixelSlice<'_, Rgb<u8>> = PixelSlice::from(img);
     EncodeRequest::new(ImageFormat::Avif)
         .with_quality(quality)
@@ -215,9 +211,7 @@ fn avif_exif_round_trip_preserves_blob() {
         .expect("EXIF should round-trip on AVIF");
     let needle = &exif[8..]; // skip 8-byte TIFF header — search for IFD bytes
     assert!(
-        extracted
-            .windows(needle.len())
-            .any(|w| w == needle),
+        extracted.windows(needle.len()).any(|w| w == needle),
         "EXIF round-trip should contain the original IFD payload"
     );
 }
@@ -323,19 +317,14 @@ fn decode_gain_map_returns_none_for_plain_avif() {
 // CICP = (1, 16, 6, true) = BT.709 primaries + PQ transfer + BT.709 matrix
 // + full range. 10-bit. Real-world HDR AVIF shipped by content pipelines.
 
-const HDR_AVIF_FIXTURE: &str =
-    "/mnt/v/input/gainmap-samples/avif/seine_hdr_gainmap_srgb.avif";
+const HDR_AVIF_FIXTURE: &str = "/mnt/v/input/gainmap-samples/avif/seine_hdr_gainmap_srgb.avif";
 
 #[ignore = "needs gainmap-samples corpus at /mnt/v/input/; run with cargo test -- --ignored"]
 #[test]
 fn avif_hdr_fixture_surfaces_pq_transfer_characteristic() {
-    let bytes = std::fs::read(HDR_AVIF_FIXTURE)
-        .expect("HDR AVIF fixture must be present");
-    let info = zencodecs::from_bytes_with_registry(
-        &bytes,
-        &zencodecs::AllowedFormats::all(),
-    )
-    .expect("probe HDR AVIF");
+    let bytes = std::fs::read(HDR_AVIF_FIXTURE).expect("HDR AVIF fixture must be present");
+    let info = zencodecs::from_bytes_with_registry(&bytes, &zencodecs::AllowedFormats::all())
+        .expect("probe HDR AVIF");
     let cicp = info
         .source_color
         .cicp
@@ -351,13 +340,9 @@ fn avif_hdr_fixture_surfaces_pq_transfer_characteristic() {
 #[ignore = "needs gainmap-samples corpus at /mnt/v/input/; run with cargo test -- --ignored"]
 #[test]
 fn avif_hdr_fixture_surfaces_10bit_depth() {
-    let bytes = std::fs::read(HDR_AVIF_FIXTURE)
-        .expect("HDR AVIF fixture must be present");
-    let info = zencodecs::from_bytes_with_registry(
-        &bytes,
-        &zencodecs::AllowedFormats::all(),
-    )
-    .expect("probe HDR AVIF");
+    let bytes = std::fs::read(HDR_AVIF_FIXTURE).expect("HDR AVIF fixture must be present");
+    let info = zencodecs::from_bytes_with_registry(&bytes, &zencodecs::AllowedFormats::all())
+        .expect("probe HDR AVIF");
     assert_eq!(
         info.source_color.bit_depth,
         Some(10),
@@ -374,8 +359,7 @@ fn avif_hdr_fixture_surfaces_10bit_depth() {
 #[test]
 fn avif_hdr_fixture_decode_preserves_10bit_pixel_width() {
     use zenpixels::ChannelType;
-    let bytes = std::fs::read(HDR_AVIF_FIXTURE)
-        .expect("HDR AVIF fixture must be present");
+    let bytes = std::fs::read(HDR_AVIF_FIXTURE).expect("HDR AVIF fixture must be present");
     let decoded = DecodeRequest::new(&bytes)
         .decode_full_frame()
         .expect("decode HDR AVIF");
@@ -399,7 +383,6 @@ fn avif_hdr_fixture_decode_preserves_10bit_pixel_width() {
 fn decode_gain_map_handles_garbage_avif_without_panic() {
     // Truncated AVIF magic. Implementation must error or return None,
     // never panic.
-    let bytes: Vec<u8> = b"\x00\x00\x00\x20ftypavif\x00\x00\x00\x00garbage"
-        .to_vec();
+    let bytes: Vec<u8> = b"\x00\x00\x00\x20ftypavif\x00\x00\x00\x00garbage".to_vec();
     let _ = DecodeRequest::new(&bytes).decode_gain_map();
 }

--- a/zencodecs/tests/avif_gainmap_diagnostic.rs
+++ b/zencodecs/tests/avif_gainmap_diagnostic.rs
@@ -29,7 +29,11 @@ fn zenavif_trait_path_with_metadata_writes_exif_item() {
     use zencodec::encode::{EncodeJob as _, Encoder as _, EncoderConfig as _};
 
     let base_pixels: Vec<Rgb<u8>> = (0..16 * 16)
-        .map(|i| Rgb { r: (i % 16) as u8, g: 80, b: 50 })
+        .map(|i| Rgb {
+            r: (i % 16) as u8,
+            g: 80,
+            b: 50,
+        })
         .collect();
     let base = imgref::ImgVec::new(base_pixels, 16, 16);
 
@@ -49,12 +53,10 @@ fn zenavif_trait_path_with_metadata_writes_exif_item() {
     job = job.with_metadata(meta);
     let encoder = job.encoder().expect("build encoder");
 
-    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> =
-        zenpixels::PixelSlice::from(base.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> = zenpixels::PixelSlice::from(base.as_ref());
     let result = encoder.encode(typed.erase()).expect("encode");
 
-    let parser = zenavif_parse::AvifParser::from_bytes(result.as_ref())
-        .expect("parse");
+    let parser = zenavif_parse::AvifParser::from_bytes(result.as_ref()).expect("parse");
     let exif_result = parser.exif();
     assert!(
         exif_result.is_some(),
@@ -73,7 +75,11 @@ fn zenavif_trait_path_with_metadata_writes_exif_item() {
 #[test]
 fn bare_zenavif_with_exif_actually_writes_exif_item() {
     let base_pixels: Vec<Rgb<u8>> = (0..16 * 16)
-        .map(|i| Rgb { r: (i % 16) as u8, g: 80, b: 50 })
+        .map(|i| Rgb {
+            r: (i % 16) as u8,
+            g: 80,
+            b: 50,
+        })
         .collect();
     let base = imgref::ImgVec::new(base_pixels, 16, 16);
 
@@ -95,8 +101,8 @@ fn bare_zenavif_with_exif_actually_writes_exif_item() {
     )
     .expect("bare zenavif encode with EXIF");
 
-    let parser = zenavif_parse::AvifParser::from_bytes(&result.avif_file)
-        .expect("parse zenavif AVIF");
+    let parser =
+        zenavif_parse::AvifParser::from_bytes(&result.avif_file).expect("parse zenavif AVIF");
     let exif_result = parser.exif();
     assert!(
         exif_result.is_some(),
@@ -126,7 +132,11 @@ fn compare_bare_vs_zencodecs_exif_byte_search() {
     use zencodecs::{EncodeRequest, ImageFormat, Metadata};
 
     let pixels: Vec<Rgb<u8>> = (0..16 * 16)
-        .map(|i| Rgb { r: (i % 16) as u8, g: 80, b: 50 })
+        .map(|i| Rgb {
+            r: (i % 16) as u8,
+            g: 80,
+            b: 50,
+        })
         .collect();
     let img = imgref::ImgVec::new(pixels, 16, 16);
 
@@ -150,8 +160,7 @@ fn compare_bare_vs_zencodecs_exif_byte_search() {
     .expect("bare encode");
 
     // zencodecs full path
-    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> =
-        zenpixels::PixelSlice::from(img.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> = zenpixels::PixelSlice::from(img.as_ref());
     let zen = EncodeRequest::new(ImageFormat::Avif)
         .with_quality(80.0)
         .with_metadata(Metadata::none().with_exif(exif.clone()))
@@ -160,22 +169,17 @@ fn compare_bare_vs_zencodecs_exif_byte_search() {
     let zen_bytes = zen.into_vec();
 
     // Find "Exif" 4-byte marker (box header convention).
-    let bare_has_exif = bare
-        .avif_file
-        .windows(4)
-        .any(|w| w == b"Exif" || w == b"infe" && bare.avif_file.windows(8).any(|w8| w8 == b"infeExif"));
-    let zen_has_exif = zen_bytes
-        .windows(4)
-        .any(|w| w == b"Exif");
+    let bare_has_exif = bare.avif_file.windows(4).any(|w| {
+        w == b"Exif" || w == b"infe" && bare.avif_file.windows(8).any(|w8| w8 == b"infeExif")
+    });
+    let zen_has_exif = zen_bytes.windows(4).any(|w| w == b"Exif");
 
     let bare_unique_idx = bare.avif_file.windows(4).position(|w| w == b"Exif");
     let zen_unique_idx = zen_bytes.windows(4).position(|w| w == b"Exif");
 
-    let bare_parser = zenavif_parse::AvifParser::from_bytes(&bare.avif_file)
-        .expect("parse bare");
+    let bare_parser = zenavif_parse::AvifParser::from_bytes(&bare.avif_file).expect("parse bare");
     let bare_parsed = bare_parser.exif().is_some();
-    let zen_parser = zenavif_parse::AvifParser::from_bytes(&zen_bytes)
-        .expect("parse zen");
+    let zen_parser = zenavif_parse::AvifParser::from_bytes(&zen_bytes).expect("parse zen");
     let zen_parsed = zen_parser.exif().is_some();
 
     let _ = bare_has_exif;
@@ -203,11 +207,14 @@ fn zencodecs_with_metadata_exif_actually_writes_exif_item() {
     use zencodecs::{EncodeRequest, ImageFormat, Metadata};
 
     let base_pixels: Vec<Rgb<u8>> = (0..16 * 16)
-        .map(|i| Rgb { r: (i % 16) as u8, g: 80, b: 50 })
+        .map(|i| Rgb {
+            r: (i % 16) as u8,
+            g: 80,
+            b: 50,
+        })
         .collect();
     let base = imgref::ImgVec::new(base_pixels, 16, 16);
-    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> =
-        zenpixels::PixelSlice::from(base.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> = zenpixels::PixelSlice::from(base.as_ref());
 
     // Minimal valid EXIF blob: TIFF header + 1 IFD entry (Orientation=6).
     let mut exif = Vec::new();
@@ -228,8 +235,8 @@ fn zencodecs_with_metadata_exif_actually_writes_exif_item() {
         .expect("zencodecs encode AVIF with EXIF metadata")
         .into_vec();
 
-    let parser = zenavif_parse::AvifParser::from_bytes(&avif_bytes)
-        .expect("parse zencodecs-emitted AVIF");
+    let parser =
+        zenavif_parse::AvifParser::from_bytes(&avif_bytes).expect("parse zencodecs-emitted AVIF");
     let exif_result = parser.exif();
     assert!(
         exif_result.is_some(),
@@ -253,9 +260,7 @@ fn zencodecs_encode_with_precomputed_gainmap_actually_embeds_tmap() {
     use zencodecs::{EncodeRequest, GainMapSource, ImageFormat};
 
     // Build a synthetic gain map struct manually (no need for a donor).
-    let gm_pixels: Vec<u8> = (0..16 * 16 * 3)
-        .map(|i| ((i * 7) % 256) as u8)
-        .collect();
+    let gm_pixels: Vec<u8> = (0..16 * 16 * 3).map(|i| ((i * 7) % 256) as u8).collect();
     let gain_map = zencodecs::gainmap::GainMap {
         data: gm_pixels,
         width: 16,
@@ -279,8 +284,7 @@ fn zencodecs_encode_with_precomputed_gainmap_actually_embeds_tmap() {
         })
         .collect();
     let base = imgref::ImgVec::new(base_pixels, 32, 32);
-    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> =
-        zenpixels::PixelSlice::from(base.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<u8>> = zenpixels::PixelSlice::from(base.as_ref());
 
     let avif_bytes = EncodeRequest::new(ImageFormat::Avif)
         .with_quality(80.0)
@@ -292,8 +296,8 @@ fn zencodecs_encode_with_precomputed_gainmap_actually_embeds_tmap() {
         .expect("zencodecs encode with gain map")
         .into_vec();
 
-    let parser = zenavif_parse::AvifParser::from_bytes(&avif_bytes)
-        .expect("parse zencodecs-emitted AVIF");
+    let parser =
+        zenavif_parse::AvifParser::from_bytes(&avif_bytes).expect("parse zencodecs-emitted AVIF");
     let gm_result = parser.gain_map();
     assert!(
         gm_result.is_some(),
@@ -331,12 +335,9 @@ fn zenavif_with_gain_map_actually_embeds_tmap_item() {
         zencodec::StopToken::new(zencodec::enough::Unstoppable),
     )
     .expect("encode gain map AVIF");
-    let parser = zenavif_parse::AvifParser::from_bytes(&gm_avif.avif_file)
-        .expect("parse gain map AVIF");
-    let av1_data = parser
-        .primary_data()
-        .expect("extract primary AV1")
-        .to_vec();
+    let parser =
+        zenavif_parse::AvifParser::from_bytes(&gm_avif.avif_file).expect("parse gain map AVIF");
+    let av1_data = parser.primary_data().expect("extract primary AV1").to_vec();
 
     // Synthetic ISO 21496-1 metadata blob.
     let iso_metadata = vec![0u8; 64];
@@ -359,8 +360,7 @@ fn zenavif_with_gain_map_actually_embeds_tmap_item() {
     // Inspect the output AVIF directly with zenavif_parse — does it see
     // a gain map item? This is the binary question we care about.
     let parser =
-        zenavif_parse::AvifParser::from_bytes(&main_avif.avif_file)
-            .expect("parse main AVIF");
+        zenavif_parse::AvifParser::from_bytes(&main_avif.avif_file).expect("parse main AVIF");
 
     // The parser should expose some gain map indication. Try the most
     // likely accessor and assert it's not None.
@@ -370,9 +370,7 @@ fn zenavif_with_gain_map_actually_embeds_tmap_item() {
         "AVIF encoded with .with_gain_map(...) must contain a tmap aux item — \
          parser.gain_map() returned None"
     );
-    let gm = gm_result
-        .unwrap()
-        .expect("gain map item resolves cleanly");
+    let gm = gm_result.unwrap().expect("gain map item resolves cleanly");
     assert!(
         !gm.gain_map_data.is_empty(),
         "tmap AV1 data must be non-empty"

--- a/zencodecs/tests/common/mod.rs
+++ b/zencodecs/tests/common/mod.rs
@@ -24,7 +24,12 @@ pub fn rgba8_image(w: usize, h: usize) -> ImgVec<Rgba<u8>> {
         .map(|i| {
             let x = (i % w) as u8;
             let y = (i / w) as u8;
-            Rgba { r: x, g: y, b: 128, a: 200 }
+            Rgba {
+                r: x,
+                g: y,
+                b: 128,
+                a: 200,
+            }
         })
         .collect();
     ImgVec::new(pixels, w, h)

--- a/zencodecs/tests/cross_codec_gainmap.rs
+++ b/zencodecs/tests/cross_codec_gainmap.rs
@@ -19,9 +19,7 @@
 
 use imgref::ImgVec;
 use rgb::Rgb;
-use zencodecs::{
-    DecodeRequest, EncodeRequest, GainMapSource, ImageFormat, PixelBufferConvertExt,
-};
+use zencodecs::{DecodeRequest, EncodeRequest, GainMapSource, ImageFormat, PixelBufferConvertExt};
 
 // ─── Fixture ─────────────────────────────────────────────────────────────
 
@@ -43,11 +41,7 @@ fn make_hdr_gradient(w: usize, h: usize, peak: f32) -> ImgVec<Rgb<f32>> {
 /// Encode a synthetic HDR image as a UltraHDR JPEG and decode it back to
 /// `(SDR base pixels, gain map, metadata)`. This is the "donor" used by
 /// the cross-codec re-encode tests below.
-fn build_jpeg_donor(
-    w: usize,
-    h: usize,
-    peak: f32,
-) -> zencodecs::DecodedGainMap {
+fn build_jpeg_donor(w: usize, h: usize, peak: f32) -> zencodecs::DecodedGainMap {
     let img = make_hdr_gradient(w, h, peak);
     let bytes = EncodeRequest::new(ImageFormat::Jpeg)
         .with_quality(90.0)
@@ -95,8 +89,7 @@ fn jpeg_ultrahdr_gainmap_re_embeds_into_jpeg_ultrahdr() {
     let (_, gm_out) = DecodeRequest::new(&bytes)
         .decode_gain_map()
         .expect("decode JPEG gain map");
-    let gm_out = gm_out
-        .expect("JPEG → JPEG via with_gain_map(Precomputed) must round-trip");
+    let gm_out = gm_out.expect("JPEG → JPEG via with_gain_map(Precomputed) must round-trip");
 
     assert_eq!(gm_out.source_format, ImageFormat::Jpeg);
     assert!(!gm_out.base_is_hdr, "JPEG forward direction preserved");
@@ -118,14 +111,16 @@ fn jpeg_ultrahdr_gainmap_re_embeds_into_jpeg_ultrahdr() {
 #[test]
 fn jpeg_ultrahdr_gainmap_re_embeds_into_avif_tmap() {
     let donor = build_jpeg_donor(64, 64, 4.0);
-    assert!(!donor.base_is_hdr, "JPEG UltraHDR must be forward direction");
+    assert!(
+        !donor.base_is_hdr,
+        "JPEG UltraHDR must be forward direction"
+    );
 
     // Build a fresh SDR base in linear-light f32 (the AVIF encoder
     // accepts whatever format its EncodeRequest takes; the gain map
     // attaches via with_gain_map).
     let img = make_hdr_gradient(64, 64, 1.0); // peak=1.0 → SDR-only base
-    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> =
-        zenpixels::PixelSlice::from(img.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> = zenpixels::PixelSlice::from(img.as_ref());
 
     let avif_bytes = EncodeRequest::new(ImageFormat::Avif)
         .with_quality(85.0)
@@ -149,9 +144,7 @@ fn jpeg_ultrahdr_gainmap_re_embeds_into_avif_tmap() {
     );
     // Headroom must round-trip within tolerance — re-encoding can lose
     // a tiny bit of precision in the metadata serialisation.
-    let dh = (donor.metadata.alternate_hdr_headroom
-        - gm_out.metadata.alternate_hdr_headroom)
-        .abs();
+    let dh = (donor.metadata.alternate_hdr_headroom - gm_out.metadata.alternate_hdr_headroom).abs();
     assert!(
         dh < 0.05,
         "alternate_hdr_headroom must round-trip within 0.05; got Δ = {dh}"
@@ -166,8 +159,7 @@ fn avif_tmap_gainmap_re_embeds_into_jpeg_ultrahdr() {
     // Build an AVIF donor by going JPEG → AVIF first, then re-extract.
     let jpeg_donor = build_jpeg_donor(48, 48, 3.5);
     let img = make_hdr_gradient(48, 48, 1.0);
-    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> =
-        zenpixels::PixelSlice::from(img.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> = zenpixels::PixelSlice::from(img.as_ref());
     let avif_bytes = EncodeRequest::new(ImageFormat::Avif)
         .with_quality(85.0)
         .with_gain_map(GainMapSource::Precomputed {
@@ -213,14 +205,10 @@ fn avif_tmap_gainmap_re_embeds_into_jpeg_ultrahdr() {
     let (_, jpeg_round_tripped) = DecodeRequest::new(&jpeg_bytes)
         .decode_gain_map()
         .expect("decode round-tripped JPEG");
-    let jpeg_round_tripped =
-        jpeg_round_tripped.expect("AVIF→JPEG must produce a gain map");
+    let jpeg_round_tripped = jpeg_round_tripped.expect("AVIF→JPEG must produce a gain map");
 
     assert_eq!(jpeg_round_tripped.source_format, ImageFormat::Jpeg);
-    assert!(
-        !jpeg_round_tripped.base_is_hdr,
-        "JPEG UltraHDR base is SDR"
-    );
+    assert!(!jpeg_round_tripped.base_is_hdr, "JPEG UltraHDR base is SDR");
 }
 
 // ─── JPEG → JXL (forward → inverse — the direction-flip case) ────────────
@@ -243,8 +231,7 @@ fn jpeg_ultrahdr_gainmap_re_embeds_into_jxl_jhgm() {
     // For a JXL encode with the JXL convention, the base image should
     // be HDR. We provide HDR pixels here.
     let hdr = make_hdr_gradient(32, 32, 4.0);
-    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> =
-        zenpixels::PixelSlice::from(hdr.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> = zenpixels::PixelSlice::from(hdr.as_ref());
 
     let jxl_bytes = EncodeRequest::new(ImageFormat::Jxl)
         .with_quality(95.0)
@@ -265,8 +252,7 @@ fn jpeg_ultrahdr_gainmap_re_embeds_into_jxl_jhgm() {
     // (degenerate but at least the metadata round-trips). What we
     // refuse: a missing or zero-valued metadata block.
     assert!(
-        gm_out.metadata.alternate_hdr_headroom > 0.0
-            || gm_out.metadata.base_hdr_headroom > 0.0,
+        gm_out.metadata.alternate_hdr_headroom > 0.0 || gm_out.metadata.base_hdr_headroom > 0.0,
         "JXL round-tripped gain map must declare some HDR headroom"
     );
 }
@@ -279,8 +265,7 @@ fn avif_encode_without_with_gain_map_produces_plain_avif() {
     // Sanity: omitting `with_gain_map` must not somehow magic a gain map
     // into the output. This pins the negative case for the resplit path.
     let img = make_hdr_gradient(32, 32, 4.0);
-    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> =
-        zenpixels::PixelSlice::from(img.as_ref());
+    let typed: zenpixels::PixelSlice<'_, Rgb<f32>> = zenpixels::PixelSlice::from(img.as_ref());
     let bytes = EncodeRequest::new(ImageFormat::Avif)
         .with_quality(85.0)
         .encode(typed.erase(), false)

--- a/zencodecs/tests/jpeg_capability.rs
+++ b/zencodecs/tests/jpeg_capability.rs
@@ -65,8 +65,7 @@ fn encode_jpeg_rgba8_ignore_alpha(img: ImgRef<'_, Rgba<u8>>, quality: f32) -> Ve
     let typed: PixelSlice<'_, Rgba<u8>> = PixelSlice::from(img);
     let pixels = typed
         .with_descriptor(
-            PixelDescriptor::RGBA8_SRGB
-                .with_alpha(Some(zenpixels::AlphaMode::Undefined)),
+            PixelDescriptor::RGBA8_SRGB.with_alpha(Some(zenpixels::AlphaMode::Undefined)),
         )
         .erase();
     EncodeRequest::new(ImageFormat::Jpeg)
@@ -229,10 +228,7 @@ fn jpeg_xmp_round_trip_preserves_marker() {
     let decoded = decode_full(&bytes);
 
     let extracted_meta = decoded.info().metadata();
-    let extracted = extracted_meta
-        .xmp
-        .as_ref()
-        .expect("XMP should round-trip");
+    let extracted = extracted_meta.xmp.as_ref().expect("XMP should round-trip");
     let s = core::str::from_utf8(extracted).expect("XMP must be UTF-8");
     assert!(
         s.contains("capability test marker"),

--- a/zencodecs/tests/jxl_capability.rs
+++ b/zencodecs/tests/jxl_capability.rs
@@ -145,10 +145,7 @@ fn jxl_rgb_f32_hdr_encode_decode_round_trip() {
     // should reflect the f32 input (or the codec's chosen wider type),
     // not silently narrow to 8.
     let bit_depth = decoded.info().source_color.bit_depth;
-    assert!(
-        bit_depth.is_some(),
-        "JXL must report bit_depth on decode"
-    );
+    assert!(bit_depth.is_some(), "JXL must report bit_depth on decode");
 }
 
 #[cfg(feature = "jxl-encode")]
@@ -235,10 +232,7 @@ fn jxl_valid_icc_round_trip() {
         .icc_profile
         .as_ref()
         .expect("valid ICC must round-trip on JXL");
-    assert!(
-        !extracted.is_empty(),
-        "round-tripped ICC must not be empty"
-    );
+    assert!(!extracted.is_empty(), "round-tripped ICC must not be empty");
 }
 
 // ─── CICP / color space ───────────────────────────────────────────────────
@@ -313,8 +307,7 @@ fn decode_gain_map_returns_none_for_plain_jxl() {
 #[test]
 fn decode_gain_map_handles_garbage_jxl_without_panic() {
     // JXL container magic followed by garbage. Must not panic.
-    let bytes: Vec<u8> = b"\x00\x00\x00\x0cJXL \r\n\x87\ngarbage past header"
-        .to_vec();
+    let bytes: Vec<u8> = b"\x00\x00\x00\x0cJXL \r\n\x87\ngarbage past header".to_vec();
     let _ = DecodeRequest::new(&bytes).decode_gain_map();
 }
 
@@ -336,11 +329,7 @@ fn decode_gain_map_handles_garbage_jxl_without_panic() {
 ///
 /// This is the cross-codec direction-flip case the audit flagged as
 /// the highest-risk JXL gain map test.
-#[cfg(all(
-    feature = "jxl-encode",
-    feature = "jpeg",
-    feature = "jpeg-ultrahdr"
-))]
+#[cfg(all(feature = "jxl-encode", feature = "jpeg", feature = "jpeg-ultrahdr"))]
 #[test]
 fn jxl_gainmap_round_trip_inverse_direction() {
     // Source: an UltraHDR JPEG (forward direction).
@@ -391,21 +380,15 @@ fn jxl_gainmap_round_trip_inverse_direction() {
 //                     → BT.2020 primaries + HLG transfer + identity matrix.
 // `pq_gradient.jxl`:  1088×64, 16-bit, CICP (1, 16, 0, true) → BT.709 + PQ.
 
-const HDR_PQ_JXL_FIXTURE: &str =
-    "/mnt/v/GitHub/codec-corpus/jxl/features/hdr_pq_test.jxl";
-const HDR_HLG_JXL_FIXTURE: &str =
-    "/mnt/v/GitHub/codec-corpus/jxl/features/hdr_hlg_test.jxl";
+const HDR_PQ_JXL_FIXTURE: &str = "/mnt/v/GitHub/codec-corpus/jxl/features/hdr_pq_test.jxl";
+const HDR_HLG_JXL_FIXTURE: &str = "/mnt/v/GitHub/codec-corpus/jxl/features/hdr_hlg_test.jxl";
 
 #[ignore = "needs codec-corpus JXL features corpus; run with cargo test -- --ignored"]
 #[test]
 fn jxl_hdr_pq_fixture_surfaces_rec2020_primaries_and_pq_transfer() {
-    let bytes = std::fs::read(HDR_PQ_JXL_FIXTURE)
-        .expect("HDR PQ JXL fixture must be present");
-    let info = zencodecs::from_bytes_with_registry(
-        &bytes,
-        &zencodecs::AllowedFormats::all(),
-    )
-    .expect("probe JXL HDR PQ");
+    let bytes = std::fs::read(HDR_PQ_JXL_FIXTURE).expect("HDR PQ JXL fixture must be present");
+    let info = zencodecs::from_bytes_with_registry(&bytes, &zencodecs::AllowedFormats::all())
+        .expect("probe JXL HDR PQ");
     let cicp = info.source_color.cicp.expect("JXL must surface CICP");
     assert_eq!(
         cicp.color_primaries, 9,
@@ -423,13 +406,9 @@ fn jxl_hdr_pq_fixture_surfaces_rec2020_primaries_and_pq_transfer() {
 #[ignore = "needs codec-corpus JXL features corpus; run with cargo test -- --ignored"]
 #[test]
 fn jxl_hdr_hlg_fixture_surfaces_hlg_transfer() {
-    let bytes = std::fs::read(HDR_HLG_JXL_FIXTURE)
-        .expect("HDR HLG JXL fixture must be present");
-    let info = zencodecs::from_bytes_with_registry(
-        &bytes,
-        &zencodecs::AllowedFormats::all(),
-    )
-    .expect("probe JXL HDR HLG");
+    let bytes = std::fs::read(HDR_HLG_JXL_FIXTURE).expect("HDR HLG JXL fixture must be present");
+    let info = zencodecs::from_bytes_with_registry(&bytes, &zencodecs::AllowedFormats::all())
+        .expect("probe JXL HDR HLG");
     let cicp = info.source_color.cicp.expect("JXL must surface CICP");
     assert_eq!(
         cicp.transfer_characteristics, 18,
@@ -442,8 +421,7 @@ fn jxl_hdr_hlg_fixture_surfaces_hlg_transfer() {
 #[test]
 fn jxl_hdr_fixture_decode_preserves_10bit_pixel_width() {
     use zenpixels::ChannelType;
-    let bytes = std::fs::read(HDR_PQ_JXL_FIXTURE)
-        .expect("HDR PQ JXL fixture must be present");
+    let bytes = std::fs::read(HDR_PQ_JXL_FIXTURE).expect("HDR PQ JXL fixture must be present");
     let decoded = DecodeRequest::new(&bytes)
         .decode_full_frame()
         .expect("decode HDR PQ JXL");

--- a/zencodecs/tests/raw_capability.rs
+++ b/zencodecs/tests/raw_capability.rs
@@ -33,10 +33,8 @@
 
 use zencodecs::DecodeRequest;
 
-const APPLE_PRORAW_FIXTURE: &str =
-    "/mnt/v/heic/46CD6167-C36B-4F98-B386-2300D8E840F0.DNG";
-const APPLE_PRORAW_FIXTURE_2: &str =
-    "/mnt/v/heic/CBFA569A-5C28-468E-96B4-CFFBAEB951C7.DNG";
+const APPLE_PRORAW_FIXTURE: &str = "/mnt/v/heic/46CD6167-C36B-4F98-B386-2300D8E840F0.DNG";
+const APPLE_PRORAW_FIXTURE_2: &str = "/mnt/v/heic/CBFA569A-5C28-468E-96B4-CFFBAEB951C7.DNG";
 
 // ─── Fixture-free tests ───────────────────────────────────────────────────
 
@@ -45,22 +43,27 @@ const APPLE_PRORAW_FIXTURE_2: &str =
 fn raw_probe_handles_garbage_without_panic() {
     let bytes = b"not a raw file at all, just garbage bytes";
     // probe will return Err(UnrecognizedFormat) — never panic.
-    let _ = zencodecs::from_bytes_with_registry(
-        bytes,
-        &zencodecs::AllowedFormats::all(),
-    );
+    let _ = zencodecs::from_bytes_with_registry(bytes, &zencodecs::AllowedFormats::all());
 }
 
 /// `decode_gain_map` on a regular JPEG must NOT spuriously match the
 /// Apple ProRAW MPF path. The dispatcher should detect "regular JPEG,
 /// no UltraHDR XMP, no Apple MPF gain map" and return None.
-#[cfg(all(feature = "jpeg", feature = "jpeg-ultrahdr", feature = "raw-decode-gainmap"))]
+#[cfg(all(
+    feature = "jpeg",
+    feature = "jpeg-ultrahdr",
+    feature = "raw-decode-gainmap"
+))]
 #[test]
 fn decode_gain_map_returns_none_for_jpeg_without_apple_mpf() {
     use imgref::ImgVec;
     use rgb::Rgb;
     let pixels: Vec<Rgb<u8>> = (0..32 * 32)
-        .map(|i| Rgb { r: (i % 32) as u8, g: 0, b: 0 })
+        .map(|i| Rgb {
+            r: (i % 32) as u8,
+            g: 0,
+            b: 0,
+        })
         .collect();
     let img = ImgVec::new(pixels, 32, 32);
     let bytes = zencodecs::EncodeRequest::new(zencodec::ImageFormat::Jpeg)
@@ -94,8 +97,16 @@ fn apple_proraw_dng_decode_succeeds_and_reports_dimensions() {
         .decode_full_frame()
         .expect("Apple ProRAW DNG must decode via Custom dispatch");
     let info = decoded.info();
-    assert!(info.width > 0, "DNG width should be > 0, got {}", info.width);
-    assert!(info.height > 0, "DNG height should be > 0, got {}", info.height);
+    assert!(
+        info.width > 0,
+        "DNG width should be > 0, got {}",
+        info.width
+    );
+    assert!(
+        info.height > 0,
+        "DNG height should be > 0, got {}",
+        info.height
+    );
 }
 
 /// Apple ProRAW DNGs carry DNG-specific EXIF tags (camera color
@@ -112,8 +123,7 @@ fn apple_proraw_dng_decode_succeeds_and_reports_dimensions() {
 #[ignore = "needs Apple ProRAW DNG at /mnt/v/heic/; run with cargo test -- --ignored"]
 #[test]
 fn apple_proraw_dng_exif_carries_dng_tags() {
-    let bytes = std::fs::read(APPLE_PRORAW_FIXTURE)
-        .expect("Apple ProRAW fixture must be present");
+    let bytes = std::fs::read(APPLE_PRORAW_FIXTURE).expect("Apple ProRAW fixture must be present");
     let exif_meta = DecodeRequest::new(&bytes)
         .with_format(zencodec::ImageFormat::Custom(&zenraw::DNG_FORMAT))
         .read_raw_metadata()
@@ -125,8 +135,7 @@ fn apple_proraw_dng_exif_carries_dng_tags() {
     );
     // Apple ProRAW DNG-specific: at least one of the color matrices.
     assert!(
-        exif_meta.color_matrix_1.is_some()
-            || exif_meta.color_matrix_2.is_some(),
+        exif_meta.color_matrix_1.is_some() || exif_meta.color_matrix_2.is_some(),
         "Apple ProRAW must carry at least one ColorMatrix DNG tag"
     );
     // AsShotNeutral is the white-balance reference for raw conversion.
@@ -147,8 +156,7 @@ fn apple_proraw_dng_exif_carries_dng_tags() {
 #[should_panic(expected = "raw EXIF blob")]
 #[test]
 fn apple_proraw_dng_raw_exif_blob_attached_to_info() {
-    let bytes = std::fs::read(APPLE_PRORAW_FIXTURE)
-        .expect("Apple ProRAW fixture must be present");
+    let bytes = std::fs::read(APPLE_PRORAW_FIXTURE).expect("Apple ProRAW fixture must be present");
     let decoded = DecodeRequest::new(&bytes)
         .with_format(zencodec::ImageFormat::Custom(&zenraw::DNG_FORMAT))
         .decode_full_frame()
@@ -165,16 +173,13 @@ fn apple_proraw_dng_raw_exif_blob_attached_to_info() {
 #[ignore = "needs Apple ProRAW DNG at /mnt/v/heic/; run with cargo test -- --ignored"]
 #[test]
 fn apple_proraw_dng_yields_gain_map() {
-    let bytes = std::fs::read(APPLE_PRORAW_FIXTURE)
-        .expect("Apple ProRAW fixture must be present");
+    let bytes = std::fs::read(APPLE_PRORAW_FIXTURE).expect("Apple ProRAW fixture must be present");
 
     let (_decoded, gm) = DecodeRequest::new(&bytes)
         .with_format(zencodec::ImageFormat::Custom(&zenraw::DNG_FORMAT))
         .decode_gain_map()
         .expect("decode_gain_map on Apple ProRAW must not error");
-    let gm = gm.expect(
-        "Apple ProRAW DNG must yield a gain map via the MPF preview path"
-    );
+    let gm = gm.expect("Apple ProRAW DNG must yield a gain map via the MPF preview path");
 
     assert!(
         gm.gain_map.width > 0 && gm.gain_map.height > 0,
@@ -198,8 +203,8 @@ fn apple_proraw_dng_second_fixture_round_trips_gain_map_metadata() {
     // Variant fixture: confirms the Apple MPF path isn't tied to one
     // specific file's quirks. If both fixtures decode and yield gain
     // maps with consistent metadata shape, the path is reliable.
-    let bytes = std::fs::read(APPLE_PRORAW_FIXTURE_2)
-        .expect("second Apple ProRAW fixture must be present");
+    let bytes =
+        std::fs::read(APPLE_PRORAW_FIXTURE_2).expect("second Apple ProRAW fixture must be present");
 
     let (_decoded, gm) = DecodeRequest::new(&bytes)
         .with_format(zencodec::ImageFormat::Custom(&zenraw::DNG_FORMAT))

--- a/zencodecs/tests/webp_capability.rs
+++ b/zencodecs/tests/webp_capability.rs
@@ -54,11 +54,7 @@ fn encode_webp_rgba8(img: ImgRef<'_, Rgba<u8>>, quality: f32) -> Vec<u8> {
         .into_vec()
 }
 
-fn encode_webp_with_meta(
-    img: ImgRef<'_, Rgb<u8>>,
-    meta: Metadata,
-    quality: f32,
-) -> Vec<u8> {
+fn encode_webp_with_meta(img: ImgRef<'_, Rgb<u8>>, meta: Metadata, quality: f32) -> Vec<u8> {
     let typed: PixelSlice<'_, Rgb<u8>> = PixelSlice::from(img);
     EncodeRequest::new(ImageFormat::WebP)
         .with_quality(quality)

--- a/zeneditor/src/command.rs
+++ b/zeneditor/src/command.rs
@@ -58,10 +58,7 @@ pub enum Command {
     SetParamBool { key: String, value: bool },
 
     /// Set the film look preset and intensity.
-    SetFilmPreset {
-        id: Option<String>,
-        intensity: f32,
-    },
+    SetFilmPreset { id: Option<String>, intensity: f32 },
 
     /// Reset a single parameter to its identity value.
     ResetParam { key: String },
@@ -111,7 +108,10 @@ pub enum Command {
     SetExportDims { width: u32, height: u32 },
 
     /// Set a format-specific export option (e.g. quality, effort, lossless).
-    SetExportOption { key: String, value: serde_json::Value },
+    SetExportOption {
+        key: String,
+        value: serde_json::Value,
+    },
 
     /// Request an encode at overview size (for inline preview in export modal).
     EncodePreview,
@@ -120,9 +120,7 @@ pub enum Command {
     EncodeFull,
 
     /// Set HDR handling mode.
-    SetHdrMode {
-        mode: crate::model::export::HdrMode,
-    },
+    SetHdrMode { mode: crate::model::export::HdrMode },
 
     /// Set metadata preservation policy.
     SetMetadataPolicy {

--- a/zeneditor/src/decode.rs
+++ b/zeneditor/src/decode.rs
@@ -64,9 +64,7 @@ pub fn decode_native(bytes: &[u8]) -> Result<NativeDecodeOutput, String> {
             let mut packed = Vec::with_capacity(dst_row_bytes * height as usize);
             for y in 0..height as usize {
                 let start = y * src_stride;
-                packed.extend_from_slice(
-                    &pixels.as_strided_bytes()[start..start + dst_row_bytes],
-                );
+                packed.extend_from_slice(&pixels.as_strided_bytes()[start..start + dst_row_bytes]);
             }
             packed
         }

--- a/zeneditor/src/model/adjustment.rs
+++ b/zeneditor/src/model/adjustment.rs
@@ -74,7 +74,8 @@ impl AdjustmentModel {
         if old == Some(value) {
             return false;
         }
-        self.values.insert(key.to_string(), ParamValue::Number(value));
+        self.values
+            .insert(key.to_string(), ParamValue::Number(value));
         self.touched.insert(key.to_string());
         true
     }
@@ -114,10 +115,8 @@ impl AdjustmentModel {
     /// Reset all parameters to identity.
     pub fn reset_all(&mut self, schema: &SchemaModel) {
         for desc in schema.all_params() {
-            self.values.insert(
-                desc.adjust_key.clone(),
-                ParamValue::Number(desc.identity),
-            );
+            self.values
+                .insert(desc.adjust_key.clone(), ParamValue::Number(desc.identity));
         }
         self.touched.clear();
         self.film_preset = None;
@@ -150,10 +149,7 @@ impl AdjustmentModel {
     ///
     /// Output: `{"zenfilters.exposure": {"stops": 1.5}, ...}`
     /// Only includes nodes where at least one param differs from identity.
-    pub fn to_pipeline_format(
-        &self,
-        schema: &SchemaModel,
-    ) -> BTreeMap<String, serde_json::Value> {
+    pub fn to_pipeline_format(&self, schema: &SchemaModel) -> BTreeMap<String, serde_json::Value> {
         schema.build_pipeline_adjustments(&self.values)
     }
 

--- a/zeneditor/src/model/geometry.rs
+++ b/zeneditor/src/model/geometry.rs
@@ -115,7 +115,10 @@ pub enum RotationMode {
     /// §13.1: `Rotate` struct with Lanczos3 interpolation.
     /// `border` controls edge handling.
     #[serde(rename = "arbitrary")]
-    Arbitrary { degrees: f32, border: RotationBorder },
+    Arbitrary {
+        degrees: f32,
+        border: RotationBorder,
+    },
     /// Auto-deskew — detect skew angle and correct.
     /// §11.3: "Auto-straighten: detect horizon line and auto-rotate to level"
     /// §13.1: zenfilters `Warp::deskew()` via rotate.

--- a/zeneditor/src/model/schema.rs
+++ b/zeneditor/src/model/schema.rs
@@ -342,10 +342,7 @@ impl SchemaModel {
                     }
                     ParamKind::Number => {
                         let n = val.as_f64();
-                        node_params.insert(
-                            p.param_name.clone(),
-                            serde_json::Value::from(n),
-                        );
+                        node_params.insert(p.param_name.clone(), serde_json::Value::from(n));
                         if (n - p.identity).abs() > 1e-6 {
                             any_changed = true;
                         }
@@ -355,8 +352,11 @@ impl SchemaModel {
 
             // Assemble arrays
             for (arr_name, acc) in &arrays {
-                let arr_val: Vec<serde_json::Value> =
-                    acc.values.iter().map(|v| serde_json::Value::from(*v)).collect();
+                let arr_val: Vec<serde_json::Value> = acc
+                    .values
+                    .iter()
+                    .map(|v| serde_json::Value::from(*v))
+                    .collect();
                 node_params.insert(arr_name.clone(), serde_json::Value::Array(arr_val));
                 if acc.any_changed {
                     any_changed = true;
@@ -390,7 +390,10 @@ fn parse_numeric_param(
     schema: &serde_json::Value,
     group: &str,
 ) -> ParamDescriptor {
-    let min = schema.get("minimum").and_then(|v| v.as_f64()).unwrap_or(0.0);
+    let min = schema
+        .get("minimum")
+        .and_then(|v| v.as_f64())
+        .unwrap_or(0.0);
     let max = schema
         .get("maximum")
         .and_then(|v| v.as_f64())
@@ -408,10 +411,7 @@ fn parse_numeric_param(
         .and_then(|v| v.as_f64())
         .unwrap_or(0.01);
 
-    let slider = match schema
-        .get("x-zennode-slider")
-        .and_then(|v| v.as_str())
-    {
+    let slider = match schema.get("x-zennode-slider").and_then(|v| v.as_str()) {
         Some("square_from_slider") => SliderType::SquareFromSlider,
         Some("factor_centered") => SliderType::FactorCentered,
         _ => SliderType::Linear,

--- a/zeneditor/src/state.rs
+++ b/zeneditor/src/state.rs
@@ -24,9 +24,7 @@ use zenpipe::sources::MaterializedSource;
 use crate::command::Command;
 #[cfg(feature = "encode")]
 use crate::encode::{EncodeResult, encode_pixels};
-use crate::model::{
-    AdjustmentModel, ExportModel, HistoryModel, RegionModel, SchemaModel,
-};
+use crate::model::{AdjustmentModel, ExportModel, HistoryModel, RegionModel, SchemaModel};
 use crate::pipeline::{RenderOutput, make_source_info, pack_rgba};
 use crate::view_update::ViewUpdate;
 
@@ -136,8 +134,9 @@ impl EditorState {
 
     /// Initialize from pre-decoded RGBA8 sRGB pixels.
     pub fn init_from_rgba(&mut self, pixels: Vec<u8>, width: u32, height: u32) {
-        self.source_pixels =
-            Some(MaterializedSource::from_data(pixels, width, height, RGBA8_SRGB));
+        self.source_pixels = Some(MaterializedSource::from_data(
+            pixels, width, height, RGBA8_SRGB,
+        ));
         self.source_width = width;
         self.source_height = height;
         self.source_hash = compute_hash(width, height, None);
@@ -158,8 +157,9 @@ impl EditorState {
         metadata: zencodec::Metadata,
         format: zencodec::ImageFormat,
     ) {
-        self.source_pixels =
-            Some(MaterializedSource::from_data(pixels, width, height, RGBA8_SRGB));
+        self.source_pixels = Some(MaterializedSource::from_data(
+            pixels, width, height, RGBA8_SRGB,
+        ));
         self.source_width = width;
         self.source_height = height;
         self.metadata = Some(metadata);
@@ -178,7 +178,10 @@ impl EditorState {
     /// browser-decoded preview; this replaces those pixels with the correct
     /// high-quality decode and preserves metadata.
     #[cfg(feature = "decode")]
-    pub fn init_from_bytes(&mut self, bytes: &[u8]) -> Result<crate::decode::NativeDecodeOutput, String> {
+    pub fn init_from_bytes(
+        &mut self,
+        bytes: &[u8],
+    ) -> Result<crate::decode::NativeDecodeOutput, String> {
         let decoded = crate::decode::decode_native(bytes)?;
         let output_info = crate::decode::NativeDecodeOutput {
             data: Vec::new(), // don't clone the pixels for the return value
@@ -248,10 +251,7 @@ impl EditorState {
             } => {
                 self.init_from_rgba(data, width, height);
                 vec![
-                    ViewUpdate::SourceLoaded {
-                        width,
-                        height,
-                    },
+                    ViewUpdate::SourceLoaded { width, height },
                     ViewUpdate::RenderNeeded,
                 ]
             }
@@ -329,10 +329,7 @@ impl EditorState {
                     self.render_needed = true;
                     self.detail_only = false;
                     vec![
-                        ViewUpdate::ParamChanged {
-                            key,
-                            value,
-                        },
+                        ViewUpdate::ParamChanged { key, value },
                         ViewUpdate::RenderNeeded,
                     ]
                 } else {
@@ -601,25 +598,23 @@ impl EditorState {
                 }]
             }
 
-            Command::LoadRecipe { json } => {
-                match crate::model::Recipe::from_json(&json) {
-                    Ok(recipe) => {
-                        self.apply_recipe(&recipe);
-                        self.render_needed = true;
-                        self.detail_only = false;
-                        vec![
-                            ViewUpdate::RecipeLoaded,
-                            ViewUpdate::AllParamsReset,
-                            ViewUpdate::GeometryChanged,
-                            ViewUpdate::RenderNeeded,
-                        ]
-                    }
-                    Err(e) => vec![ViewUpdate::Error {
-                        message: e,
-                        recoverable: false,
-                    }],
+            Command::LoadRecipe { json } => match crate::model::Recipe::from_json(&json) {
+                Ok(recipe) => {
+                    self.apply_recipe(&recipe);
+                    self.render_needed = true;
+                    self.detail_only = false;
+                    vec![
+                        ViewUpdate::RecipeLoaded,
+                        ViewUpdate::AllParamsReset,
+                        ViewUpdate::GeometryChanged,
+                        ViewUpdate::RenderNeeded,
+                    ]
                 }
-            }
+                Err(e) => vec![ViewUpdate::Error {
+                    message: e,
+                    recoverable: false,
+                }],
+            },
 
             Command::GetSchema => {
                 vec![ViewUpdate::Schema {
@@ -811,10 +806,7 @@ impl EditorState {
     /// Encode at overview size for inline preview in the export modal.
     #[cfg(feature = "encode")]
     pub fn encode_preview(&mut self) -> Result<EncodeResult, String> {
-        self.encode_at_overview_size(
-            &self.export.format.clone(),
-            &self.export.options.clone(),
-        )
+        self.encode_at_overview_size(&self.export.format.clone(), &self.export.options.clone())
     }
 
     /// Encode at full resolution for download.
@@ -935,12 +927,7 @@ impl EditorState {
 
     /// Save current state as a recipe.
     pub fn save_recipe(&self, name: Option<String>) -> crate::model::Recipe {
-        crate::model::recipe::snapshot_recipe(
-            &self.geometry,
-            &self.adjustments,
-            &self.export,
-            name,
-        )
+        crate::model::recipe::snapshot_recipe(&self.geometry, &self.adjustments, &self.export, name)
     }
 
     /// Apply a recipe, overwriting current adjustments, geometry, and export.
@@ -1238,7 +1225,11 @@ mod tests {
         });
 
         assert!(state.render_needed());
-        assert!(updates.iter().any(|u| matches!(u, ViewUpdate::RenderNeeded)));
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::RenderNeeded))
+        );
     }
 
     #[test]
@@ -1251,12 +1242,16 @@ mod tests {
         state.render_needed = true;
 
         let updates = state.render_if_needed().unwrap();
-        assert!(updates
-            .iter()
-            .any(|u| matches!(u, ViewUpdate::OverviewPixels { .. })));
-        assert!(updates
-            .iter()
-            .any(|u| matches!(u, ViewUpdate::DetailPixels { .. })));
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::OverviewPixels { .. }))
+        );
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::DetailPixels { .. }))
+        );
     }
 
     #[test]
@@ -1305,9 +1300,11 @@ mod tests {
         state.adjustments.set("zenfilters.exposure.stops", 1.5);
 
         let updates = state.dispatch(Command::ResetAll);
-        assert!(updates
-            .iter()
-            .any(|u| matches!(u, ViewUpdate::AllParamsReset)));
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::AllParamsReset))
+        );
     }
 
     #[test]
@@ -1322,9 +1319,11 @@ mod tests {
             h: 0.4,
         });
 
-        assert!(updates
-            .iter()
-            .any(|u| matches!(u, ViewUpdate::RegionChanged { .. })));
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::RegionChanged { .. }))
+        );
         assert!((state.region.x - 0.1).abs() < 1e-6);
     }
 
@@ -1400,12 +1399,19 @@ mod tests {
 
         // Load recipe
         let updates = state.dispatch(Command::LoadRecipe { json });
-        assert!(updates.iter().any(|u| matches!(u, ViewUpdate::RecipeLoaded)));
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::RecipeLoaded))
+        );
 
         // Verify state was restored
         assert!(state.geometry.flip_h);
         assert_eq!(state.adjustments.film_preset.as_deref(), Some("portra"));
-        assert_eq!(state.export.hdr_mode, crate::model::export::HdrMode::Tonemap);
+        assert_eq!(
+            state.export.hdr_mode,
+            crate::model::export::HdrMode::Tonemap
+        );
     }
 
     #[test]
@@ -1414,16 +1420,29 @@ mod tests {
         state.init_from_rgba(solid_rgba(100, 100, 128, 128, 128), 100, 100);
 
         let updates = state.dispatch(Command::SetCrop {
-            crop: crate::model::geometry::CropMode::Percent { x: 0.1, y: 0.1, w: 0.8, h: 0.8 },
+            crop: crate::model::geometry::CropMode::Percent {
+                x: 0.1,
+                y: 0.1,
+                w: 0.8,
+                h: 0.8,
+            },
         });
-        assert!(updates.iter().any(|u| matches!(u, ViewUpdate::GeometryChanged)));
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::GeometryChanged))
+        );
         assert!(state.render_needed());
 
         let updates = state.dispatch(Command::SetFlip {
             horizontal: true,
             vertical: false,
         });
-        assert!(updates.iter().any(|u| matches!(u, ViewUpdate::GeometryChanged)));
+        assert!(
+            updates
+                .iter()
+                .any(|u| matches!(u, ViewUpdate::GeometryChanged))
+        );
         assert!(state.geometry.flip_h);
         assert!(!state.geometry.flip_v);
     }

--- a/zeneditor/src/view_update.rs
+++ b/zeneditor/src/view_update.rs
@@ -40,23 +40,14 @@ pub enum ViewUpdate {
     AllParamsReset,
 
     /// Film preset selection changed.
-    FilmPresetChanged {
-        id: Option<String>,
-        intensity: f32,
-    },
+    FilmPresetChanged { id: Option<String>, intensity: f32 },
 
     /// Undo/redo state changed.
-    HistoryChanged {
-        can_undo: bool,
-        can_redo: bool,
-    },
+    HistoryChanged { can_undo: bool, can_redo: bool },
 
     // ─── Source info ───
     /// Source image loaded and ready.
-    SourceLoaded {
-        width: u32,
-        height: u32,
-    },
+    SourceLoaded { width: u32, height: u32 },
 
     /// Source upgraded with native decode (metadata now available).
     MetadataUpgraded {
@@ -124,10 +115,7 @@ pub enum ViewUpdate {
     // ─── Errors ───
     /// An error occurred. If `recoverable`, the editor auto-reverts to
     /// last safe state.
-    Error {
-        message: String,
-        recoverable: bool,
-    },
+    Error { message: String, recoverable: bool },
 
     // ─── Status ───
     /// A render started (overview + detail).


### PR DESCRIPTION
Addresses the 2026-05-06 security audit (`/home/lilith/work/feedback/security-audit-2026-05-06/zenpipe.md`). Three commits, one logical fix per commit, regression tests in `tests/security_audit.rs`.

## CRITICAL fixes

- **C1 — graph cycle-check stack overflow.** `dfs_cycle_check` (`src/graph.rs`) was recursive with no depth cap, so a long linear DAG bypassed the existing `MAX_GRAPH_DEPTH = 256` checks in `estimate_node`/`compile_node_inner` and crashed the process. Rewrote as iterative DFS with an explicit work stack. Regression: `audit_c1_deep_linear_dag_does_not_stack_overflow` builds a 10k-node linear chain and runs `validate()` without overflow.
- **C2 — `width × height × bpp` overflow on 32-bit / wasm32 / i686.** Added `limits::checked_buffer_size`, `checked_stride_buffer`, `checked_dim_add` helpers. Routed every dim-arithmetic site in source constructors through them, returning `PipeError::LimitExceeded` on wrap rather than allocating a wrapped-to-zero (or wrong-size) buffer that later panics at the consumer. Sites covered: `CropSource`, `EdgeReplicateSource`, `ExpandCanvasSource`, `MaterializedSource`, `TeeSource`, `EffectSource`, `DecoderSource`, `CompositeSource`, `IccTransformSource`, `WindowedFilterSource`, `MatteFlattenOp`, `ScaleAlphaOp`. `StripBuf` gains `try_new`/`try_reconfigure` (fail with `LimitExceeded`); the infallible variants now panic with descriptive messages instead of wrapping. Regression: `audit_c2_checked_buffer_size_rejects_overflow`, `audit_c2_checked_stride_buffer_rejects_overflow`, `audit_c2_checked_dim_add_rejects_wrap`.
- **C3 — `AllocationTracker` had zero in-tree callers.** Now wired through the source constructors that allocate beyond a single strip (Materialize, Tee, WindowedFilter, EffectSource, ExpandCanvas/EdgeReplicate bg-rows, IccTransform buffer). Combined with H1 below.

## HIGH fixes

- **H1 — TOCTOU + u64 overflow in `AllocationTracker`.** `allocate()` rewritten as a `compare_exchange_weak` loop with `checked_add` for the bounds calculation. Regressions: `audit_h1_allocation_tracker_rejects_u64_overflow`, `audit_h1_allocation_tracker_enforces_limit_concurrently` (8 threads each requesting `limit/2 + 1` — only one succeeds).
- **H2 — `CropSource` wrap-around dims.** `CropSource::new` rejects `x.checked_add(w)` / `y.checked_add(h)` overflow. `next()` uses `saturating_add` for `upstream_y`. Regressions: `audit_h2_crop_rejects_x_plus_w_wrap`, `audit_h2_crop_rejects_y_plus_h_wrap`.
- **H3 — `ExpandCanvasSource` `i32::MIN` negation, RGB8 corruption, infallible alloc.** Replaced `-place_x` with `place_x.unsigned_abs()`. Branched bg-row fill on `bpp` instead of assuming `chunks_exact_mut(4)` (now correct for RGB8/U16/F32). Made `new()` fallible on `canvas_w * bpp` overflow. Regression: `audit_h3_expand_canvas_accepts_i32_min_place`.
- **H4 — `WindowedFilterSource` overlap math + cast_slice panics.** `checked_mul` on `overlap*6` and `strip+2*overlap`; full-frame f32 buffers go through the new helpers. Replaced `bytemuck::cast_slice` on upstream rows with a length-validating helper that returns `DimensionMismatch`.
- **H5 — `CompositeSource` per-row alloc + alignment panic.** Pre-allocate `composite_row_buf` once at construction. Added `saturating_add` for fg/bg overlap math. Validate f32 alignment before `bytemuck::cast_slice`.
- **H6 — `IccTransformSource` src/dst stride mismatch.** Source slice now uses `strip.stride()`; destination uses the format's aligned stride. Defensive length validation before slicing rather than letting bad input panic.
- **H7 — u32 dim-add overflow in graph estimator.** `ExpandCanvas` estimate now uses `checked_add` for canvas-dim accumulation so the estimate doesn't undercount memory and bypass `Limits::check`.
- **H8 — Animation transcode uncancellable.** Added `transcode_with_stop` and `transcode_with_stop_and_limits`. Stop is checked between frames and inside per-frame `execute`. `max_frames` is now enforced per iteration so decoders that lazy-report `frame_count = None` don't bypass the limit.

## MEDIUM fixes

- **M4 — `find_input` silently dropped multiple Input edges.** `validate()` now rejects more than one incoming edge of the same kind for non-multi-input nodes.
- **M5 — `peak_memory_bytes` u64 add overflow.** Switched to `saturating_add`; saturation is treated as limit-exceeded.
- **M7 — `MatteFlattenOp` / `ScaleAlphaOp` width×height overflow.** Iterate via `chunks_exact(4)` over the buffer directly — no manual indexing, compiler bounds the loop by buffer length.
- **M9 — `WatermarkLayout::compute_bounding_box`.** Reject u32 wrap on `left+right` / `top+bottom` and reject margin values that don't fit i32 before signed arithmetic.

## Deferred (TODOs for follow-up PRs)

The audit's MEDIUM/LOW backlog beyond M4/M5/M7/M9. None are reachable critical/high; documenting here so they're not lost:

- M1: convert remaining `assert!`/`unwrap()`/`expect()`/`unreachable!()` reachable from public API to `PipeError` returns (`TransformSource::push_boxed`, `RowConverterOp::must`, `FilterSource::new`, `StripBuf::as_strip` `expect`, `execute_layout` asserts, several `unwrap`/`unreachable` paths in `graph.rs`, `Mutex::lock().unwrap()` in `trace.rs`).
- M2: O(N²)/O(N³) DAG building in `bridge/dag.rs::identify_chains` — index-based rewrite needed.
- M3: `EffectSource` re-check `limits` between effects (output dims can grow per effect).
- M6: cancellation gaps inside `EffectSource` rotation loop, `MaterializedSource::from_source[_with_transform]` (un-stoppable), `TeeSource::new` (un-stoppable), per-strip filter loop in `WindowedFilterSource`.
- M8: `bridge/geometry.rs` percent-coordinate float-to-u32 saturation can produce `u32::MAX`; needs `[0, 100]` validation + NaN/inf rejection.
- M10: `DecoderSource::new` trusts `decoder.info()` dims without limit check; add `new_with_limits`.
- L1–L7: WindowedFilter strip-buffer cap; EdgeReplicate canvas-vs-content validation; CallbackSource per-row alloc; TransformSource Stop check between fused ops; `find_input` linear scan; `compile_node_inner` re-traversal on diamond DAGs; remaining `bytemuck::cast_slice` panic surfaces in `mask_transform.rs`, `resize.rs`, `ops.rs`.
- A graph-builder fuzz target (`PipelineGraph` constructions through `validate → estimate → compile`) was recommended in the audit and is also deferred.

## Test plan

- [x] `cargo test --all-targets` — 530 passed, 0 failed (includes 9 new `tests/security_audit.rs` cases).
- [x] `cargo test --doc` — 6 passed, 0 failed.
- [x] `cargo clippy --all-targets` — no errors.
- [x] `cargo build` — clean.
- [ ] CI on `windows-11-arm`, `macos-15-intel`, `i686-unknown-linux-gnu` (will run on push).