### PR TITLE
feat(hdr): re-embed the source gain map on transcode (#45 S4)

### DIFF
--- a/zencodecs/src/transcode.rs
+++ b/zencodecs/src/transcode.rs
@@ -207,11 +207,29 @@ pub fn transcode(
         SupplementPolicy::Strip => false,
     };
 
-    // Step 1: Decode the source image (full materialization for now)
-    let decoded = crate::DecodeRequest::new(data)
-        .with_registry(registry)
-        .with_gain_map_extraction(wants_gain_map)
-        .decode_full_frame()?;
+    // Step 1: Decode the source image (full materialization for now). When the
+    // caller preserves supplements and the build has gain-map support, also
+    // recover the decoded gain map so it can be re-embedded (passthrough) below.
+    #[cfg(feature = "jpeg-ultrahdr")]
+    let (decoded, gain_map) = if wants_gain_map {
+        crate::DecodeRequest::new(data)
+            .with_registry(registry)
+            .decode_gain_map()?
+    } else {
+        (
+            crate::DecodeRequest::new(data)
+                .with_registry(registry)
+                .decode_full_frame()?,
+            None,
+        )
+    };
+    #[cfg(not(feature = "jpeg-ultrahdr"))]
+    let decoded = {
+        let _ = wants_gain_map;
+        crate::DecodeRequest::new(data)
+            .with_registry(registry)
+            .decode_full_frame()?
+    };
 
     // Step 2: Determine metadata to embed
     let metadata = match opts.metadata.clone() {
@@ -249,6 +267,20 @@ pub fn transcode(
     }
 
     let buffer = decoded.into_buffer();
+
+    // Passthrough re-embed: carry the source gain map into the target container
+    // unchanged. `DecodedGainMap.gain_map` / `.metadata` are already exactly the
+    // types `GainMapSource::Precomputed` borrows (`ultrahdr_core::GainMap` and
+    // the `zencodec::GainMapParams` alias) — no conversion, no recomputation.
+    // A target encoder without gain-map support ignores it.
+    #[cfg(feature = "jpeg-ultrahdr")]
+    if let Some(ref dgm) = gain_map {
+        request = request.with_gain_map(crate::gainmap::GainMapSource::Precomputed {
+            gain_map: &dgm.gain_map,
+            metadata: &dgm.metadata,
+        });
+    }
+
     let encode_output = request.encode(buffer.as_slice(), buffer.descriptor().has_alpha())?;
 
     Ok(TranscodeOutput {


### PR DESCRIPTION
**S4 of the M×N HDR pipeline** (imazen/zenpixels#45) — and **independently landable** (pre-existing APIs only).

## Problem
`transcode()` decoded → re-encoded but **dropped the gain map** — it was extracted (`with_gain_map_extraction`) then discarded. So UltraHDR JPEG → {AVIF, JXL, JPEG} silently lost its HDR.

## Fix (passthrough, ~20 lines)
When supplements are preserved, recover the `DecodedGainMap` (`decode_gain_map`) and re-embed it via `EncodeRequest::with_gain_map(GainMapSource::Precomputed{..})`.

**No bridging** — and that's the point. `DecodedGainMap.gain_map` is already `ultrahdr_core::GainMap` and `.metadata` is the `zencodec::GainMapParams` alias (ultrahdr-core 0.5+: `pub type GainMapMetadata = zencodec::GainMapParams`), i.e. *exactly* the types `GainMapSource::Precomputed` borrows. The struct is documented "for passthrough/transcode." (I'd previously talked myself out of this by misreading that alias as two incompatible cross-crate types — there was never a conversion to write.)

Gated behind `jpeg-ultrahdr`; default builds unchanged. Both configs compile, clippy/fmt clean.

## Landability
Uses only pre-existing zencodecs APIs — independent of the HDR-anchor stack.

## Follow-up test (recommended)
In `tests/gainmap_roundtrip.rs`: transcode an UltraHDR JPEG with `SupplementPolicy::Preserve` to a gain-map-capable target, decode, and assert the gain map survives. The re-embed is passthrough (no pixel transform), so this proves the container plumbing, not the math.
