### PR TITLE
fix(limits): bump pixel caps 100MP→120MP (admit 108MP phone photos)

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ println!("peak: {} bytes", estimate.peak_memory_bytes());
 
 // Enforce limits before execution
 estimate.check(&Limits {
-    max_megapixels: Some(100),
+    max_pixels: Some(120_000_000), // 120 MP — admits 108 MP phone photos
     max_memory_bytes: Some(512 * 1024 * 1024),
     ..Default::default()
 })?;

--- a/src/imageflow_compat/execute.rs
+++ b/src/imageflow_compat/execute.rs
@@ -1067,8 +1067,8 @@ fn collect_decode_infos(
     infos
 }
 
-/// Maximum pixel count for a canvas (100 megapixels).
-const MAX_CANVAS_PIXELS: u64 = 100_000_000;
+/// Maximum pixel count for a canvas (120 megapixels — admits 108 MP phone photos).
+const MAX_CANVAS_PIXELS: u64 = 120_000_000;
 
 /// Check dimensions against a security FrameSizeLimit.
 fn check_security_limit(

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -33,7 +33,7 @@ use crate::format::PixelFormat;
 /// use zenpipe::Limits;
 ///
 /// let limits = Limits::default()
-///     .with_max_pixels(100_000_000)   // 100 megapixels
+///     .with_max_pixels(120_000_000)   // 120 megapixels
 ///     .with_max_width(16384)
 ///     .with_max_height(16384)
 ///     .with_max_frames(10000);
@@ -75,10 +75,13 @@ impl Limits {
         max_duration: None,
     };
 
-    /// Server-safe defaults: 100 megapixels, 16384 max dimension, 4 GB memory,
+    /// Server-safe defaults: 120 megapixels, 16384 max dimension, 4 GB memory,
     /// 10 000 animation frames, 1 billion total pixels across all frames.
+    ///
+    /// 120 MP admits 108 MP phone-camera photos (a common real-world size)
+    /// while still rejecting decode-bomb dimensions.
     pub const SERVER: Self = Self {
-        max_pixels: Some(100_000_000),
+        max_pixels: Some(120_000_000),
         max_memory_bytes: Some(4 * 1024 * 1024 * 1024),
         max_width: Some(16384),
         max_height: Some(16384),

--- a/zencodecs/src/limits.rs
+++ b/zencodecs/src/limits.rs
@@ -52,13 +52,16 @@ impl Limits {
 
     /// Production-safe limits for real-time image proxies processing untrusted input.
     ///
-    /// 16384x16384 max dimensions, 100 megapixels, 512 MB memory, 100 MB input,
+    /// 16384x16384 max dimensions, 120 megapixels, 512 MB memory, 100 MB input,
     /// 1000 frames, 60 seconds duration.
+    ///
+    /// 120 MP admits 108 MP phone-camera photos (a common real-world size)
+    /// while still bounding decode work for untrusted input.
     pub fn for_proxy() -> Self {
         Self {
             max_width: Some(16_384),
             max_height: Some(16_384),
-            max_pixels: Some(100_000_000),
+            max_pixels: Some(120_000_000),
             max_memory_bytes: Some(512 * 1024 * 1024),
             max_input_bytes: Some(100 * 1024 * 1024),
             max_output_bytes: Some(100 * 1024 * 1024),


### PR DESCRIPTION
## What

Raises the pixel-count caps that gate decode/processing of untrusted input from **100 MP to 120 MP**, so 108 MP phone-camera photos (now common) are admitted instead of rejected.

| Site | Was | Now |
|---|---|---|
| `Limits::SERVER.max_pixels` (`src/limits.rs`) | 100 M | 120 M |
| `zencodecs Limits::for_proxy().max_pixels` | 100 M | 120 M |
| `imageflow_compat MAX_CANVAS_PIXELS` | 100 M | 120 M |

Memory (4 GB / 512 MB), dimension (16384), and frame caps are unchanged — 120 MP still rejects decode-bomb dimensions.

## Why non-breaking

Every change *raises* a ceiling (admits more input, rejects less). No signature or type changes; the `Limits` structs are unchanged. `cargo check -p zenpipe -p zencodecs --tests` is green.

## Also

Fixes the README "Resource estimation" example, which used a non-existent `max_megapixels` field (it never compiled) — corrected to the real `max_pixels` field with a raw pixel count.

## Audit context

Found in a production-readiness audit of zenpipe + zencodecs (the dispatch-layer crates in the untrusted-input path). Both crates otherwise passed clean: comprehensive `whereat::At<E>` error-location coverage (no hot-loop `At<>`), and `enough::Stop` cancellation threaded through the pipeline/dispatch boundaries.
