### PR TITLE
docs(zenfilters readme): name PipelineError + state the linear-f32 input contract

### DIFF
--- a/zenfilters/README.md
+++ b/zenfilters/README.md
@@ -59,6 +59,41 @@ let mut dst = vec![0.0f32; w * h * 3];
 pipeline.apply(&src, &mut dst, w as u32, h as u32, 3, &mut ctx)?;
 ```
 
+`apply`'s f32 `src`/`dst` are interleaved **linear** RGB f32 in `[0, 1]` — *not*
+sRGB-encoded. Convert sRGB8 input first with
+[`linear-srgb`](https://lib.rs/crates/linear-srgb)'s `srgb_u8_to_linear_slice`,
+and re-encode the output with `linear_to_srgb_u8_slice`. (`WorkingSpace` — default
+`Oklab` — only controls the *internal* processing space; the f32 input/output
+contract is linear RGB regardless. There is also a `*_u8` entry that takes
+sRGB bytes directly.)
+
+### Errors
+
+`Pipeline::new` and `apply` return `Result<_, whereat::At<PipelineError>>` — the
+error plus the source location it was raised at, which is what a server wants in
+structured logs. Pull both with the `whereat::At` accessors (`PipelineError` is
+`#[non_exhaustive]`, so keep a wildcard arm):
+
+```rust
+use zenfilters::PipelineError;
+
+match pipeline.apply(&src, &mut dst, w, h, 3, &mut ctx) {
+    Ok(()) => {}
+    Err(e) => {
+        let loc = e.location();   // Option<&core::panic::Location> — file:line
+        match e.error() {         // &PipelineError
+            PipelineError::BufferSize { expected, actual } => { /* wrong buffer length */ }
+            PipelineError::UnsupportedPrimaries(_) => { /* unsupported color primaries */ }
+            _ => {}
+        }
+        eprintln!("filter pipeline failed at {loc:?}: {e}");
+    }
+}
+```
+
+The crate exposes no cooperative-cancellation token; a server bounding a long
+filter stack must run it on a worker and enforce a deadline at that layer.
+
 ## Presets
 
 19 built-in presets with intensity blending:


### PR DESCRIPTION
## What

Two README fixes for `zenfilters`: state that `apply`'s f32 buffers are **linear** RGB (not sRGB), and add an **Errors** section naming `PipelineError`.

## Why

An **insulated "external developer" test** (agent given only `zenfilters/README.md`, no source) hit two gaps:

1. **f32 input encoding ambiguous → silent wrong pixels.** The agent's single biggest risk (45% confidence) was guessing the `apply` f32 buffer is sRGB-encoded; it's actually interleaved **linear** RGB f32 `[0,1]` (`scatter_to_oklab(src: &[f32])` does no re-linearization; the separate `_u8` path linearizes via `srgb_u8_to_linear`, `scatter_gather.rs:98/469`). A wrong guess corrupts every pixel. Now stated explicitly, with a pointer to `linear-srgb` for the sRGB8↔linear glue.
2. **Error type never named.** The README uses `?` everywhere but never names the error, so the agent invented `Error::DimensionMismatch` etc. Both `Pipeline::new` and `apply` return `Result<_, whereat::At<PipelineError>>` (`pipeline.rs:189/409`). Added an Errors section using `e.location()` + `e.error()` with the **real** variants `BufferSize` / `UnsupportedPrimaries`, plus a no-cancellation note.

## Verification

README-only; no API change. Verified against source: `apply → Result<(), At<PipelineError>>` (`pipeline.rs:409`), `PipelineError::{UnsupportedPrimaries, BufferSize}` re-exported at `lib.rs:141`, linear-f32 scatter at `scatter_gather.rs:13/98`. Not a doctest — correctness rests on the source check. Part of a cross-crate doc pass.
