### PR TITLE
feat(zenfilters): cooperative cancellation via Pipeline::apply_with_stop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,21 @@ All notable changes to the zenpipe workspace are documented here, per crate.
   inspection), fixing the latent corruption where a resized RGBA sidecar
   was re-embedded as raw RGBA bytes labeled `channels: 3`.
 
+## zenfilters
+
+### [Unreleased]
+
+#### Added
+
+- `Pipeline::apply_with_stop` — cooperative cancellation via
+  `&dyn enough::Stop`, checked at scatter/gather strip and between-filter
+  boundaries (outer loops only, never per-pixel); `apply()` delegates with
+  `enough::Unstoppable` so the uncancellable path is byte-identical.
+  Companion `Pipeline::apply_planar_with_stop` for the manual scatter/gather
+  path. New `PipelineError::Cancelled(enough::StopReason)` variant
+  (non-breaking — the enum is already `#[non_exhaustive]`). `enough` promoted
+  to a normal dependency.
+
 ## zencodecs
 
 ### [Unreleased]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4491,6 +4491,7 @@ dependencies = [
 name = "zenfilters"
 version = "0.1.1"
 dependencies = [
+ "almost-enough",
  "archmage",
  "bytemuck",
  "codec-corpus",

--- a/docs/public-api/zenfilters.txt
+++ b/docs/public-api/zenfilters.txt
@@ -6,7 +6,7 @@
 # impls omitted; re-export duplicates annotated `[also: path]`.
 # DO NOT EDIT BY HAND — commit regenerated changes with the code.
 #
-# files: zenfilters.txt 963 lines (supported surface) | zenfilters.features.txt 852 added (features: experimental,serde,srgb-compat,srgb-filters,zennode,zenquant) | zenfilters.internal.txt 49 lines (57 hidden + 0 excluded-feature)
+# files: zenfilters.txt 966 lines (supported surface) | zenfilters.features.txt 852 added (features: experimental,serde,srgb-compat,srgb-filters,zennode,zenquant) | zenfilters.internal.txt 49 lines (57 hidden + 0 excluded-feature)
 
 ## summary
 #
@@ -14,16 +14,16 @@
 #   pub types (struct/enum/trait/alias)       120
 #   pub consts/statics                         24
 #   free functions                             30
-#   inherent methods                          158
+#   inherent methods                          160
 #   struct fields                             360
-#   enum variants                             140
+#   enum variants                             141
 #   trait roster entries (type × trait)       471
 #   conditional trait impls (verbatim)          1
 #   auto-trait-complete types                 112
 #   auto-trait exceptions                       3
 #
 # per-module pub lines:
-#   (root)                          146
+#   (root)                          149
 #   analysis                         37
 #   filter_compat                    45
 #   filters                         435
@@ -35,7 +35,7 @@
 #   resize_pipeline                   2
 #   slider                           14
 
-## items (844 lines)
+## items (847 lines)
 
 pub mod zenfilters
 pub mod analysis
@@ -754,6 +754,7 @@ pub GamutMapping::SoftCompress::knee: f32
 pub PipelineError::BufferSize
 pub PipelineError::BufferSize::actual: usize
 pub PipelineError::BufferSize::expected: usize
+pub PipelineError::Cancelled(enough::reason::StopReason)
 pub PipelineError::UnsupportedPrimaries(zenpixels::descriptor::ColorPrimaries)
 pub enum PlaneSemantics
 pub PlaneSemantics::Any
@@ -847,6 +848,8 @@ pub fn OklabPlanes::with_alpha(u32, u32) -> Self
 pub struct Pipeline
 pub fn Pipeline::apply(&self, &[f32], &mut [f32], u32, u32, u32, &mut FilterContext) -> core::result::Result<(), whereat::at::At<PipelineError>>
 pub fn Pipeline::apply_planar(&self, &mut OklabPlanes, &mut FilterContext)
+pub fn Pipeline::apply_planar_with_stop(&self, &mut OklabPlanes, &mut FilterContext, &dyn enough::Stop) -> core::result::Result<(), whereat::at::At<PipelineError>>
+pub fn Pipeline::apply_with_stop(&self, &[f32], &mut [f32], u32, u32, u32, &mut FilterContext, &dyn enough::Stop) -> core::result::Result<(), whereat::at::At<PipelineError>>
 pub fn Pipeline::config(&self) -> &PipelineConfig
 pub fn Pipeline::has_neighborhood_filter(&self) -> bool
 pub fn Pipeline::is_empty(&self) -> bool

--- a/zenfilters/CHANGELOG.md
+++ b/zenfilters/CHANGELOG.md
@@ -3,6 +3,13 @@
 ## [Unreleased]
 
 ### Added
+- `Pipeline::apply_with_stop` — cooperative cancellation via `&dyn enough::Stop`,
+  checked at scatter/gather strip and between-filter boundaries (outer loops only,
+  never per-pixel); `apply()` delegates with `enough::Unstoppable` so the
+  uncancellable path is byte-identical. Companion `Pipeline::apply_planar_with_stop`
+  for the manual scatter/gather path. New `PipelineError::Cancelled(enough::StopReason)`
+  variant (non-breaking — the enum is already `#[non_exhaustive]`). `enough` promoted
+  to a normal dependency.
 - `ClipartFlatten` filter: flattens AI-clipart "waviness" / bubble-noise inside
   nominally-flat colour regions while keeping crisp edges and intentional shading
   (complement to `BackgroundFlatten`, which only touches the background).

--- a/zenfilters/Cargo.toml
+++ b/zenfilters/Cargo.toml
@@ -27,6 +27,7 @@ zenquant = ["dep:zenquant", "dep:rgb"]
 
 [dependencies]
 archmage = { version = "0.9.17", features = ["avx512"] }
+enough = "0.4.4"
 serde = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 serde-big-array = { version = "0.5.1", optional = true }
 bytemuck = { version = "1.21", default-features = false, features = ["extern_crate_alloc"] }
@@ -43,7 +44,7 @@ zenquant = { version = "0.1.2", default-features = false, optional = true }
 imgref = "1.12"
 palette = { version = "0.7", default-features = false, features = ["std"] }
 rgb = { version = "0.8", default-features = false, features = ["as-bytes"] }
-enough = "0.4"
+almost-enough = "0.4.4"
 # 0.3.0 unpublished (crates.io tops out at 0.2.7); resolved by the workspace-root
 # git patch, same shape as zencodecs' zensim dep. CI paths it to the sibling clone.
 zensim = { version = "0.3.0", default-features = false }

--- a/zenfilters/src/pipeline.rs
+++ b/zenfilters/src/pipeline.rs
@@ -155,6 +155,8 @@ pub enum PipelineError {
     UnsupportedPrimaries(ColorPrimaries),
     /// Input buffer has wrong size.
     BufferSize { expected: usize, actual: usize },
+    /// The operation was cancelled via the cooperative-cancellation token.
+    Cancelled(enough::StopReason),
 }
 
 impl core::fmt::Display for PipelineError {
@@ -164,6 +166,7 @@ impl core::fmt::Display for PipelineError {
             Self::BufferSize { expected, actual } => {
                 write!(f, "buffer size mismatch: expected {expected}, got {actual}")
             }
+            Self::Cancelled(r) => write!(f, "operation cancelled: {r}"),
         }
     }
 }
@@ -415,6 +418,32 @@ impl Pipeline {
         channels: u32,
         ctx: &mut FilterContext,
     ) -> Result<(), At<PipelineError>> {
+        self.apply_with_stop(src, dst, width, height, channels, ctx, &enough::Unstoppable)
+    }
+
+    /// Apply the full pipeline with cooperative cancellation.
+    ///
+    /// Identical to [`apply()`](Pipeline::apply) but takes a
+    /// [`enough::Stop`] token as the final parameter. The token's
+    /// [`check()`](enough::Stop::check) is polled only at outer loop
+    /// boundaries — between scatter/gather strips and between filters —
+    /// never inside the per-pixel inner loops, so cancellation costs
+    /// nothing in the hot path. On cancellation this returns
+    /// [`PipelineError::Cancelled`] carrying the [`enough::StopReason`].
+    ///
+    /// `apply()` delegates here passing [`enough::Unstoppable`], so the
+    /// uncancellable path is byte-identical to calling this directly.
+    #[track_caller]
+    pub fn apply_with_stop(
+        &self,
+        src: &[f32],
+        dst: &mut [f32],
+        width: u32,
+        height: u32,
+        channels: u32,
+        ctx: &mut FilterContext,
+        stop: &dyn enough::Stop,
+    ) -> Result<(), At<PipelineError>> {
         let n = (width as usize) * (height as usize) * (channels as usize);
         if src.len() < n {
             return Err(at!(PipelineError::BufferSize {
@@ -435,10 +464,10 @@ impl Pipeline {
         // benchmarks show 4x slower than full-frame due to redundant
         // re-filtering of overlapping rows.
         if self.has_neighborhood_filter() {
-            return self.apply_full_frame(src, dst, width, height, channels, ctx);
+            return self.apply_full_frame(src, dst, width, height, channels, ctx, stop);
         }
 
-        self.apply_stripped(src, dst, width, height, channels, ctx)
+        self.apply_stripped(src, dst, width, height, channels, ctx, stop)
     }
 
     /// Full-frame Oklab planes with streamed color conversions.
@@ -455,6 +484,7 @@ impl Pipeline {
         height: u32,
         channels: u32,
         ctx: &mut FilterContext,
+        stop: &dyn enough::Stop,
     ) -> Result<(), At<PipelineError>> {
         let ch = channels as usize;
         let w = width as usize;
@@ -474,6 +504,7 @@ impl Pipeline {
         // Scatter in strips for cache locality
         let scatter_strip = strip_height(width, ch == 4, 0);
         for y in (0..height as usize).step_by(scatter_strip) {
+            stop.check().map_err(|r| at!(PipelineError::Cancelled(r)))?;
             let rows = scatter_strip.min(height as usize - y);
             let src_off = y * w * ch;
             let src_len = rows * w * ch;
@@ -508,10 +539,11 @@ impl Pipeline {
         }
 
         // Apply all filters on full-frame planes
-        self.apply_planar(&mut planes, ctx);
+        self.apply_planar_with_stop(&mut planes, ctx, stop)?;
 
         // Gather in strips for cache locality
         for y in (0..height as usize).step_by(scatter_strip) {
+            stop.check().map_err(|r| at!(PipelineError::Cancelled(r)))?;
             let rows = scatter_strip.min(height as usize - y);
             let dst_off = y * w * ch;
             let dst_len = rows * w * ch;
@@ -561,6 +593,7 @@ impl Pipeline {
         height: u32,
         channels: u32,
         ctx: &mut FilterContext,
+        stop: &dyn enough::Stop,
     ) -> Result<(), At<PipelineError>> {
         let ch = channels as usize;
         let w = width as usize;
@@ -569,6 +602,7 @@ impl Pipeline {
         let strip_h = strip_height(width, has_alpha, halo);
 
         for y_start in (0..height as usize).step_by(strip_h) {
+            stop.check().map_err(|r| at!(PipelineError::Cancelled(r)))?;
             let y_end = (y_start + strip_h).min(height as usize);
             let core_rows = y_end - y_start;
 
@@ -606,7 +640,7 @@ impl Pipeline {
                     self.config.reference_white,
                 );
             }
-            self.apply_planar(&mut planes, ctx);
+            self.apply_planar_with_stop(&mut planes, ctx, stop)?;
 
             // Gather only the core rows from the filtered extended strip
             let dst_offset = y_start * w * ch;
@@ -656,7 +690,27 @@ impl Pipeline {
     /// Use this when you want to manage scatter/gather yourself,
     /// or when chaining multiple pipelines on the same planar data.
     pub fn apply_planar(&self, planes: &mut OklabPlanes, ctx: &mut FilterContext) {
+        // Delegate to the cancellable variant with a no-op token; this path
+        // is byte-identical and cannot fail (`Unstoppable::check` is `Ok`).
+        let _ = self.apply_planar_with_stop(planes, ctx, &enough::Unstoppable);
+    }
+
+    /// Apply filters to already-scattered planar Oklab data, with
+    /// cooperative cancellation.
+    ///
+    /// Identical to [`apply_planar()`](Pipeline::apply_planar) but takes a
+    /// [`enough::Stop`] token. The token is polled once before each filter
+    /// runs (between filters — never per-pixel). On cancellation this
+    /// returns [`PipelineError::Cancelled`] and leaves `planes` holding the
+    /// partially-filtered result.
+    pub fn apply_planar_with_stop(
+        &self,
+        planes: &mut OklabPlanes,
+        ctx: &mut FilterContext,
+        stop: &dyn enough::Stop,
+    ) -> Result<(), At<PipelineError>> {
         for filter in &self.filters {
+            stop.check().map_err(|r| at!(PipelineError::Cancelled(r)))?;
             filter.apply(planes, ctx);
         }
 
@@ -666,6 +720,7 @@ impl Pipeline {
         {
             lut.compress_planes(&planes.l, &mut planes.a, &mut planes.b, knee);
         }
+        Ok(())
     }
 }
 
@@ -813,5 +868,105 @@ mod tests {
         pipeline.push(Box::new(sharpen));
 
         assert_eq!(pipeline.total_halo(64, 64), clarity_radius + sharpen_radius);
+    }
+
+    /// `apply_with_stop` runs to completion under an unstoppable token and
+    /// returns `Err(PipelineError::Cancelled)` under a cancelled token, on
+    /// both the per-pixel (stripped) and neighborhood (full-frame) paths.
+    #[test]
+    fn apply_with_stop_cancellation() {
+        use crate::filters;
+
+        let (w, h) = (64u32, 64u32);
+        let src = vec![0.5f32; (w as usize) * (h as usize) * 3];
+        let mut dst = vec![0.0f32; src.len()];
+        let mut ctx = FilterContext::new();
+
+        // --- Per-pixel path (no neighborhood filter → apply_stripped) ---
+        let mut per_pixel = Pipeline::new(PipelineConfig::default()).unwrap();
+        per_pixel.push(Box::new(filters::Exposure { stops: 0.3 }));
+        assert!(!per_pixel.has_neighborhood_filter());
+
+        // Unstoppable token: must succeed.
+        per_pixel
+            .apply_with_stop(&src, &mut dst, w, h, 3, &mut ctx, &enough::Unstoppable)
+            .expect("unstoppable per-pixel apply should succeed");
+
+        // Cancelled token: must report Cancelled.
+        let s = almost_enough::Stopper::new();
+        s.cancel();
+        let err = per_pixel
+            .apply_with_stop(&src, &mut dst, w, h, 3, &mut ctx, &s)
+            .expect_err("cancelled per-pixel apply should fail");
+        assert!(
+            matches!(err.error(), PipelineError::Cancelled(_)),
+            "expected Cancelled, got {:?}",
+            err.error()
+        );
+
+        // --- Neighborhood path (apply_full_frame) ---
+        let mut neighborhood = Pipeline::new(PipelineConfig::default()).unwrap();
+        neighborhood.push(Box::new(filters::Sharpen {
+            sigma: 1.0,
+            amount: 0.5,
+        }));
+        assert!(neighborhood.has_neighborhood_filter());
+
+        // Unstoppable token: must succeed.
+        neighborhood
+            .apply_with_stop(&src, &mut dst, w, h, 3, &mut ctx, &enough::Unstoppable)
+            .expect("unstoppable neighborhood apply should succeed");
+
+        // Pre-cancelled token: must report Cancelled (fires at first scatter strip).
+        let s2 = almost_enough::Stopper::cancelled();
+        let err2 = neighborhood
+            .apply_with_stop(&src, &mut dst, w, h, 3, &mut ctx, &s2)
+            .expect_err("cancelled neighborhood apply should fail");
+        assert!(
+            matches!(err2.error(), PipelineError::Cancelled(_)),
+            "expected Cancelled, got {:?}",
+            err2.error()
+        );
+
+        // `apply()` (no stop arg) must still work — delegates to Unstoppable.
+        per_pixel
+            .apply(&src, &mut dst, w, h, 3, &mut ctx)
+            .expect("plain apply should still succeed");
+    }
+
+    /// `apply_planar_with_stop` checks between filters and `apply_planar`
+    /// delegates with a no-op token (stays infallible).
+    #[test]
+    fn apply_planar_with_stop_cancellation() {
+        use crate::filters;
+
+        let (w, h) = (32u32, 32u32);
+        let mut ctx = FilterContext::new();
+        let mut pipeline = Pipeline::new(PipelineConfig::default()).unwrap();
+        pipeline.push(Box::new(filters::Exposure { stops: 0.2 }));
+        pipeline.push(Box::new(filters::Contrast { amount: 0.1 }));
+
+        // Build planes from a flat source.
+        let mut planes = OklabPlanes::from_ctx(&mut ctx, w, h);
+        for v in planes.l.iter_mut() {
+            *v = 0.5;
+        }
+
+        // Cancelled token: between-filters check trips → Cancelled.
+        let s = almost_enough::Stopper::cancelled();
+        let err = pipeline
+            .apply_planar_with_stop(&mut planes, &mut ctx, &s)
+            .expect_err("cancelled apply_planar should fail");
+        assert!(matches!(err.error(), PipelineError::Cancelled(_)));
+
+        // Unstoppable: succeeds.
+        pipeline
+            .apply_planar_with_stop(&mut planes, &mut ctx, &enough::Unstoppable)
+            .expect("unstoppable apply_planar should succeed");
+
+        // Plain apply_planar still compiles + runs (infallible delegation).
+        pipeline.apply_planar(&mut planes, &mut ctx);
+
+        planes.return_to_ctx(&mut ctx);
     }
 }


### PR DESCRIPTION
## Cooperative cancellation for `zenfilters::Pipeline` (additive, non-breaking)

Adds `&dyn enough::Stop` cancellation to the filter pipeline, matching the
pattern already shipped in `zenquant`, `fast-ssim2`, and `butteraugli`.

### What changed
- **`Pipeline::apply_with_stop(src, dst, w, h, ch, ctx, stop: &dyn enough::Stop)`** — new public method carrying the body of `apply()`.
- **`Pipeline::apply()`** now delegates with `&enough::Unstoppable` — its signature and behavior are unchanged (non-breaking).
- **`Pipeline::apply_planar_with_stop`** added; the existing public `apply_planar` is preserved and delegates with `Unstoppable`.
- **`PipelineError::Cancelled(enough::StopReason)`** — new variant. The enum is already `#[non_exhaustive]`, so this is additive.

### Where the token is checked (outer boundaries only — hot-loop safe)
Every check is the first statement of an **outer** loop; no per-pixel inner loop or SIMD kernel is touched (no register-spill cost on the throughput path):
- scatter strip loop (`apply_full_frame`, src/pipeline.rs:507)
- gather strip loop (`apply_full_frame`, :546)
- strip loop in the per-pixel path (`apply_stripped`, :605)
- between filters (`apply_planar_with_stop`, :713)

### Tests
- New `apply_with_stop_cancellation` / `apply_planar_with_stop_cancellation` exercise **both** dispatch paths (per-pixel `apply_stripped` and neighborhood `apply_full_frame`): `Ok` under `Unstoppable`, `Err(PipelineError::Cancelled)` under a cancelled `Stopper`.
- `zenfilters` lib tests: **509 passed; 0 failed**.
- Public-API snapshot regenerated (`docs/public-api/zenfilters.txt`).

### CI note — two pre-existing reds, neither introduced here
1. The workspace does not fully compile on `main` right now: a `zencodec`/`zencodecs` `#[non_exhaustive]` `ColorContext` skew (E0639) is in flight on another branch. `zenfilters` builds and tests **independently** of it.
2. `tests/quality_validation.rs::{saturation_boost_vs_vips, dt_contrast_full_corpus}` fail on `main` (verified by reverting this PR to base `ff94b13a` — identical failures, identical zensim values). They are zensim-vs-vips/darktable quality-threshold assertions, untouched by this PR.

Both are documented here so the red CI isn't mistaken for a regression from this change. The cancellation plumbing is verified green on the `zenfilters` member crate in isolation.
